### PR TITLE
Add CMake to fortran_udunits2

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,32 @@
+# Global Editor Config for MAPL
+#
+# This is an ini style configuration. See http://editorconfig.org/ for more information on this file.
+#
+# Top level editor config.
+root = true
+
+# Always use Unix style new lines with new line ending on every file and trim whitespace
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# Python: PEP8 defines 4 spaces for indentation
+[*.py]
+indent_style = space
+indent_size = 4
+
+# YAML format, 2 spaces
+[{*.yaml,*.yml}]
+indent_style = space
+indent_size = 2
+
+# CMake (from KitWare: https://github.com/Kitware/CMake/blob/master/.editorconfig)
+[{CMakeLists.txt,*.cmake,*.rst}]
+indent_style = space
+indent_size = 2
+
+# Markdown
+[*.md]
+trim_trailing_whitespace = true
+indent_style = space

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+*~
+CMakeUserPresets.json
+
+*.swp
+*.swo
+.DS_Store
+*#
+.#*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,55 @@
+cmake_minimum_required(VERSION 3.17)
+
+project(
+  "Fortran_UDUNITS2"
+  VERSION 1.0.0
+  LANGUAGES Fortran)
+
+# Add cmake directory to module path
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+# Find the UDUNITS2 library
+find_package(udunits REQUIRED)
+
+# Add source files
+set (SOURCES
+  "source/f_udunits_2.F90"
+  "source/f_udunits_2.inc"
+)
+
+# set fortran module directory
+set(CMAKE_Fortran_MODULE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/include")
+
+# Create the library
+add_library(
+  "Fortran_UDUNITS2"
+  ${SOURCES}
+)
+
+# Install the library
+install(
+  TARGETS "Fortran_UDUNITS2"
+  EXPORT "Fortran_UDUNITS2Targets"
+  LIBRARY DESTINATION "lib"
+  ARCHIVE DESTINATION "lib"
+  RUNTIME DESTINATION "bin"
+  INCLUDES DESTINATION "include"
+)
+
+# We need to install the module files
+install(
+  DIRECTORY "${CMAKE_Fortran_MODULE_DIRECTORY}/"
+  DESTINATION "include"
+)
+
+# https://www.scivision.dev/cmake-auto-gitignore-build-dir/
+# --- auto-ignore build directory
+if(NOT EXISTS ${PROJECT_BINARY_DIR}/.gitignore)
+  file(WRITE ${PROJECT_BINARY_DIR}/.gitignore "*")
+endif()
+
+# Piggyback that file into install
+install(
+   FILES ${PROJECT_BINARY_DIR}/.gitignore
+   DESTINATION ${CMAKE_INSTALL_PREFIX}
+   )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,18 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 # Find the UDUNITS2 library
 find_package(udunits REQUIRED)
 
+# Let's print some information about the library
+include(CMakePrintHelpers)
+cmake_print_properties(
+  TARGETS udunits::udunits
+  PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES
+    INTERFACE_LINK_LIBRARIES
+)
+cmake_print_variables(udunits_INCLUDE_DIR)
+cmake_print_variables(udunits_LIBRARY)
+cmake_print_variables(udunits_LIBRARY_SHARED)
+
 # Add source files
 set (SOURCES
   "source/f_udunits_2.F90"
@@ -50,6 +62,37 @@ install(
   DESTINATION "lib/cmake/Fortran_UDUNITS2"
 )
 
+# NOTE: The below bit of code is commented out because it is not
+#       working. I can't seem to figure out how to link to libxml2
+#       from macOS. I seem to be hitting the "How to link against
+#       tbd files" problem.
+#       https://discourse.cmake.org/t/newer-versions-of-macos-require-linking-against-tbd-files-and-not-old-system-paths-to-dylib/6871/3
+
+#################################################################
+# # There is a test in tests, let's add it                      #
+# enable_testing()                                              #
+#                                                               #
+# # Linking to udunits requires XML2                            #
+# find_package(LibXml2 REQUIRED)                                #
+# cmake_print_properties(                                       #
+#   TARGETS LibXml2::LibXml2                                    #
+#   PROPERTIES                                                  #
+#     INTERFACE_INCLUDE_DIRECTORIES                             #
+#     INTERFACE_LINK_LIBRARIES                                  #
+# )                                                             #
+# cmake_print_variables(LibXml2_INCLUDE_DIRS LibXml2_LIBRARIES) #
+#                                                               #
+# # Build the executable                                        #
+# add_executable(                                               #
+#   "test_f_udunits_2.exe"                                      #
+#   "tests/test_f_udunits_2.F90"                                #
+# )                                                             #
+# target_link_libraries(                                        #
+#   test_f_udunits_2.exe                                        #
+#   Fortran_UDUNITS2 udunits::udunits LibXml2::LibXml2          #
+# )                                                             #
+#                                                               #
+#################################################################
 # https://www.scivision.dev/cmake-auto-gitignore-build-dir/
 # --- auto-ignore build directory
 if(NOT EXISTS ${PROJECT_BINARY_DIR}/.gitignore)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.17)
+cmake_minimum_required(VERSION 3.23)
 
 project(
   Fortran_UDUNITS2
@@ -11,18 +11,6 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 # Find the UDUNITS2 library
 find_package(udunits REQUIRED)
 find_package(EXPAT REQUIRED)
-
-# Let's print some information about the library
-include(CMakePrintHelpers)
-cmake_print_properties(
-  TARGETS udunits::udunits
-  PROPERTIES
-    INTERFACE_INCLUDE_DIRECTORIES
-    INTERFACE_LINK_LIBRARIES
-)
-cmake_print_variables(udunits_INCLUDE_DIR)
-cmake_print_variables(udunits_LIBRARY)
-cmake_print_variables(udunits_LIBRARY_SHARED)
 
 # Add source files
 set (SOURCES
@@ -78,7 +66,7 @@ install(
   FILES
     ${CMAKE_CURRENT_BINARY_DIR}/Fortran_UDUNITS2Config.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/Fortran_UDUNITS2Config-version.cmake
-    DESTINATION "${Fortran_UDUNITS2_TOP_DIR}/cmake"
+  DESTINATION "${Fortran_UDUNITS2_TOP_DIR}/cmake"
 )
 
 install(
@@ -93,18 +81,8 @@ export(EXPORT Fortran_UDUNITS2
 )
 
 # There is a test in tests, let's add it
-# Linking to udunits requires EXPAT
-find_package(EXPAT REQUIRED)
-
-# Build the executable
-add_executable(
-  "test_f_udunits_2.exe"
-  "tests/test_f_udunits_2.F90"
-)
-target_link_libraries(
-  test_f_udunits_2.exe
-  Fortran_UDUNITS2 udunits::udunits EXPAT::EXPAT
-)
+add_executable(test_f_udunits_2.exe tests/test_f_udunits_2.F90)
+target_link_libraries(test_f_udunits_2.exe Fortran_UDUNITS2)
 
 # https://www.scivision.dev/cmake-auto-gitignore-build-dir/
 # --- auto-ignore build directory

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.17)
 
 project(
-  "Fortran_UDUNITS2"
+  Fortran_UDUNITS2
   VERSION 1.0.0
   LANGUAGES Fortran)
 
@@ -10,6 +10,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 # Find the UDUNITS2 library
 find_package(udunits REQUIRED)
+find_package(EXPAT REQUIRED)
 
 # Let's print some information about the library
 include(CMakePrintHelpers)
@@ -32,75 +33,81 @@ set (SOURCES
 # set fortran module directory
 set(CMAKE_Fortran_MODULE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/include")
 
+set (top-dir Fortran_UDUNITS2-${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR})
+set (Fortran_UDUNITS2_TOP_DIR "${CMAKE_INSTALL_PREFIX}/${top-dir}" CACHE PATH "")
+
 # Create the library
 add_library(
-  "Fortran_UDUNITS2"
+  Fortran_UDUNITS2
   ${SOURCES}
+)
+target_link_libraries(
+  Fortran_UDUNITS2
+  udunits::udunits EXPAT::EXPAT
 )
 
 # Install the library
 install(
-  TARGETS "Fortran_UDUNITS2"
-  EXPORT "Fortran_UDUNITS2Targets"
-  LIBRARY DESTINATION "lib"
-  ARCHIVE DESTINATION "lib"
-  RUNTIME DESTINATION "bin"
-  INCLUDES DESTINATION "include"
+  TARGETS Fortran_UDUNITS2
+  EXPORT Fortran_UDUNITS2
+  LIBRARY DESTINATION "${Fortran_UDUNITS2_TOP_DIR}/lib"
+  ARCHIVE DESTINATION "${Fortran_UDUNITS2_TOP_DIR}/lib"
+  RUNTIME DESTINATION "${Fortran_UDUNITS2_TOP_DIR}/bin"
+  INCLUDES DESTINATION "${Fortran_UDUNITS2_TOP_DIR}/include"
 )
 
 # We need to install the module files
 install(
   DIRECTORY "${CMAKE_Fortran_MODULE_DIRECTORY}/"
-  DESTINATION "include"
+  DESTINATION "${Fortran_UDUNITS2_TOP_DIR}/include"
 )
 
-# Install the export file
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+  Fortran_UDUNITS2Config.cmake.in
+  Fortran_UDUNITS2Config.cmake
+  INSTALL_DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/Fortran_UDUNITS2Config.cmake
+)
+write_basic_package_version_file(
+  Fortran_UDUNITS2Config-version.cmake
+  VERSION ${PROJECT_VERSION}
+  COMPATIBILITY AnyNewerVersion
+)
+
 install(
-  EXPORT "Fortran_UDUNITS2Targets"
-  FILE "Fortran_UDUNITS2Targets.cmake"
-  NAMESPACE "Fortran_UDUNITS2::"
-  DESTINATION "lib/cmake/Fortran_UDUNITS2"
+  FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/Fortran_UDUNITS2Config.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/Fortran_UDUNITS2Config-version.cmake
+    DESTINATION "${Fortran_UDUNITS2_TOP_DIR}/cmake"
 )
 
-# NOTE: The below bit of code is commented out because it is not
-#       working. I can't seem to figure out how to link to libxml2
-#       from macOS. I seem to be hitting the "How to link against
-#       tbd files" problem.
-#       https://discourse.cmake.org/t/newer-versions-of-macos-require-linking-against-tbd-files-and-not-old-system-paths-to-dylib/6871/3
+install(
+  EXPORT Fortran_UDUNITS2
+  FILE Fortran_UDUNITS2Targets.cmake
+  NAMESPACE Fortran_UDUNITS2::
+  DESTINATION "${Fortran_UDUNITS2_TOP_DIR}/cmake"
+)
+export(EXPORT Fortran_UDUNITS2
+  FILE "${CMAKE_CURRENT_BINARY_DIR}/Fortran_UDUNITS2Targets.cmake"
+  NAMESPACE Fortran_UDUNITS2::
+)
 
-#################################################################
-# # There is a test in tests, let's add it                      #
-# enable_testing()                                              #
-#                                                               #
-# # Linking to udunits requires XML2                            #
-# find_package(LibXml2 REQUIRED)                                #
-# cmake_print_properties(                                       #
-#   TARGETS LibXml2::LibXml2                                    #
-#   PROPERTIES                                                  #
-#     INTERFACE_INCLUDE_DIRECTORIES                             #
-#     INTERFACE_LINK_LIBRARIES                                  #
-# )                                                             #
-# cmake_print_variables(LibXml2_INCLUDE_DIRS LibXml2_LIBRARIES) #
-#                                                               #
-# # Build the executable                                        #
-# add_executable(                                               #
-#   "test_f_udunits_2.exe"                                      #
-#   "tests/test_f_udunits_2.F90"                                #
-# )                                                             #
-# target_link_libraries(                                        #
-#   test_f_udunits_2.exe                                        #
-#   Fortran_UDUNITS2 udunits::udunits LibXml2::LibXml2          #
-# )                                                             #
-#                                                               #
-#################################################################
+# There is a test in tests, let's add it
+# Linking to udunits requires EXPAT
+find_package(EXPAT REQUIRED)
+
+# Build the executable
+add_executable(
+  "test_f_udunits_2.exe"
+  "tests/test_f_udunits_2.F90"
+)
+target_link_libraries(
+  test_f_udunits_2.exe
+  Fortran_UDUNITS2 udunits::udunits EXPAT::EXPAT
+)
+
 # https://www.scivision.dev/cmake-auto-gitignore-build-dir/
 # --- auto-ignore build directory
 if(NOT EXISTS ${PROJECT_BINARY_DIR}/.gitignore)
   file(WRITE ${PROJECT_BINARY_DIR}/.gitignore "*")
 endif()
-
-# Piggyback that file into install
-install(
-   FILES ${PROJECT_BINARY_DIR}/.gitignore
-   DESTINATION ${CMAKE_INSTALL_PREFIX}
-   )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,14 @@ install(
   DESTINATION "include"
 )
 
+# Install the export file
+install(
+  EXPORT "Fortran_UDUNITS2Targets"
+  FILE "Fortran_UDUNITS2Targets.cmake"
+  NAMESPACE "Fortran_UDUNITS2::"
+  DESTINATION "lib/cmake/Fortran_UDUNITS2"
+)
+
 # https://www.scivision.dev/cmake-auto-gitignore-build-dir/
 # --- auto-ignore build directory
 if(NOT EXISTS ${PROJECT_BINARY_DIR}/.gitignore)

--- a/Fortran_UDUNITS2Config.cmake.in
+++ b/Fortran_UDUNITS2Config.cmake.in
@@ -1,0 +1,7 @@
+# Package configuration file
+
+@PACKAGE_INIT@
+
+set (Fortran_UDUNITS2_TOP_DIR "@Fortran_UDUNITS2_TOP_DIR@")
+
+include ("${CMAKE_CURRENT_LIST_DIR}/Fortran_UDUNITS2Targets.cmake")

--- a/README.md
+++ b/README.md
@@ -20,47 +20,47 @@ recently tested with GNU Fortran, Nvidia, AOCC, Intel Fortran compilers
 
 for all the C functions that have been interfaced:
 
-0-  the calling FORTRAN code must include
+0-  the calling Fortran code must include
           use f_udunits_2
-          to use these FORTRAN functions/subroutines
+          to use these Fortran functions/subroutines
 
-1-  the FORTRAN name will be the C name prefixed with f_
-    FORTRAN function f_ut_read_xml mimics C function ut_read_xml
+1-  the Fortran name will be the C name prefixed with f_
+    Fortran function f_ut_read_xml mimics C function ut_read_xml
 
-2-  where the C code uses a typed pointer, the FORTRAN code uses a typed object
+2-  where the C code uses a typed pointer, the Fortran code uses a typed object
 
     type(UT_SYSTEM_PTR)     replaces ut_system*
     type(UT_UNIT_PTR)       replaces ut_unit*
     type(CV_CONVERTER_PTR)  replaces cv_converter*
 
-3-  where a C function has a void return, a FORTRAN subroutine is used
+3-  where a C function has a void return, a Fortran subroutine is used
 
 4-  where a C function returns zero/nonzero for a C style true/false
-    the equivalent FORTRAN function returns a FORTRAN logical
+    the equivalent Fortran function returns a Fortran logical
       (to be usable in an equivalent way in a logical expression)
 
-5a- where a C input argument is char *, the FORTRAN code uses character(len=*)
+5a- where a C input argument is char *, the Fortran code uses character(len=*)
     copy to a C compatible zero terminated string is handled internally
-      the FORTRAN string is "trailing blanks trimmed" before the zero byte is added
+      the Fortran string is "trailing blanks trimmed" before the zero byte is added
 
-5b- where a C function returns char *, the FORTRAN function return type is character(len=256)
+5b- where a C function returns char *, the Fortran function return type is character(len=256)
 
-6-  ut_status is an integer, symbols with the same name are available to FORTRAN with
+6-  ut_status is an integer, symbols with the same name are available to Fortran with
       use f_udunits_2
 
-7-  ut_encoding is an integer, symbols with the same name are available to FORTRAN with
+7-  ut_encoding is an integer, symbols with the same name are available to Fortran with
       use f_udunits_2
 
 NOTES:
 
-FORTRAN interface(s) for function(s) returning char * (ut_trim) not implemented
-one should use the FORTRAN trim function (may not work in all cases)
+Fortran interface(s) for function(s) returning char * (ut_trim) not implemented
+one should use the Fortran trim function (may not work in all cases)
 
-FORTRAN interfaces to "visitor" functions are not implemented
+Fortran interfaces to "visitor" functions are not implemented
       ut_accept_visitor (const ut_unit* unit, const ut_visitor* visitor, void* arg)
       Data type: ut_visitor 
 
-FORTRAN interfaces to functions using a variable argument list and message handler 
+Fortran interfaces to functions using a variable argument list and message handler 
 are not implemented
    int ut_handle_error_message (const char* fmt, ...)
    ut_error_message_handler ut_set_error_message_handler (ut_error_message_handler handler)

--- a/cmake/Findudunits.cmake
+++ b/cmake/Findudunits.cmake
@@ -1,0 +1,47 @@
+# (C) Copyright 2022- UCAR.
+#
+# Try to find the udunits headers and library
+#
+# This module defines:
+#
+#   - udunits::udunits    - The udunits shared library and include directory, all in a single target.
+#   - udunits_SHARED_LIB  - The library
+#   - udunits_INCLUDE_DIR - The include directory
+#
+# The following paths will be searched in order if set in CMake (first priority) or environment (second priority):
+#
+#   - UDUNITS2_INCLUDE_DIRS & UDUNITS2_LIBRARIES - folders containing udunits2.h and libudunits2, respectively.
+#   - UDUNITS2_ROOT                 - root of udunits installation
+#   - UDUNITS2_PATH                 - root of udunits installation
+#
+# Notes:
+#   - The hint variables are capitalized because this is how they are exposed in the jedi stack.
+#     See https://github.com/JCSDA-internal/jedi-stack/blob/develop/modulefiles/compiler/compilerName/compilerVersion/udunits/udunits.lua for details.
+
+find_path (
+	udunits_INCLUDE_DIR
+	udunits2.h
+	HINTS ${UDUNITS2_INCLUDE_DIRS} $ENV{UDUNITS2_INCLUDE_DIRS}
+		${UDUNITS2_ROOT} $ENV{UDUNITS2_ROOT}
+		${UDUNITS2_PATH} $ENV{UDUNITS2_PATH}
+	DOC "Path to udunits2.h"
+	)
+find_library(udunits_SHARED_LIB
+	NAMES udunits2 udunits
+	HINTS ${UDUNITS2_LIBRARIES} $ENV{UDUNITS2_LIBRARIES}
+		${UDUNITS2_ROOT} $ENV{UDUNITS2_ROOT}
+		${UDUNITS2_PATH} $ENV{UDUNITS2_PATH}
+	DOC "Path to libudunits"
+	)
+
+include (FindPackageHandleStandardArgs)
+find_package_handle_standard_args (udunits DEFAULT_MSG udunits_SHARED_LIB udunits_INCLUDE_DIR)
+
+mark_as_advanced (udunits_SHARED_LIB udunits_INCLUDE_DIR)
+
+if(udunits_FOUND AND NOT TARGET udunits::udunits)
+	add_library(udunits::udunits INTERFACE IMPORTED)
+	set_target_properties(udunits::udunits PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${udunits_INCLUDE_DIR})
+	set_target_properties(udunits::udunits PROPERTIES INTERFACE_LINK_LIBRARIES ${udunits_SHARED_LIB})
+endif()
+

--- a/cmake/Findudunits.cmake
+++ b/cmake/Findudunits.cmake
@@ -21,21 +21,21 @@
 #     See https://github.com/JCSDA-internal/jedi-stack/blob/develop/modulefiles/compiler/compilerName/compilerVersion/udunits/udunits.lua for details.
 
 find_path (
-	udunits_INCLUDE_DIR
-	udunits2.h
-	HINTS ${UDUNITS2_INCLUDE_DIRS} $ENV{UDUNITS2_INCLUDE_DIRS}
-		${UDUNITS2_ROOT} $ENV{UDUNITS2_ROOT}
-		${UDUNITS2_PATH} $ENV{UDUNITS2_PATH}
+  udunits_INCLUDE_DIR
+  udunits2.h
+  HINTS ${UDUNITS2_INCLUDE_DIRS} $ENV{UDUNITS2_INCLUDE_DIRS}
+    ${UDUNITS2_ROOT} $ENV{UDUNITS2_ROOT}
+    ${UDUNITS2_PATH} $ENV{UDUNITS2_PATH}
   PATH_SUFFIXES include include/udunits2
-	DOC "Path to udunits2.h" )
+  DOC "Path to udunits2.h" )
 
 find_library(udunits_LIBRARY
-	NAMES udunits2 udunits
-	HINTS ${UDUNITS2_LIBRARIES} $ENV{UDUNITS2_LIBRARIES}
-		${UDUNITS2_ROOT} $ENV{UDUNITS2_ROOT}
-		${UDUNITS2_PATH} $ENV{UDUNITS2_PATH}
+  NAMES udunits2 udunits
+  HINTS ${UDUNITS2_LIBRARIES} $ENV{UDUNITS2_LIBRARIES}
+    ${UDUNITS2_ROOT} $ENV{UDUNITS2_ROOT}
+    ${UDUNITS2_PATH} $ENV{UDUNITS2_PATH}
   PATH_SUFFIXES lib64 lib
-	DOC "Path to libudunits library" )
+  DOC "Path to libudunits library" )
 
 # We need to support both static and shared libraries
 if (udunits_LIBRARY MATCHES ".*\\.a$")
@@ -50,8 +50,8 @@ find_package_handle_standard_args (udunits DEFAULT_MSG udunits_LIBRARY udunits_I
 mark_as_advanced (udunits_LIBRARY udunits_INCLUDE_DIR)
 
 if(udunits_FOUND AND NOT TARGET udunits::udunits)
-	add_library(udunits::udunits INTERFACE IMPORTED)
-	set_target_properties(udunits::udunits PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${udunits_INCLUDE_DIR})
+  add_library(udunits::udunits INTERFACE IMPORTED)
+  set_target_properties(udunits::udunits PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${udunits_INCLUDE_DIR})
   set_target_properties(udunits::udunits PROPERTIES INTERFACE_LINK_LIBRARIES ${udunits_LIBRARY})
 endif()
 

--- a/cmake/Findudunits.cmake
+++ b/cmake/Findudunits.cmake
@@ -4,9 +4,11 @@
 #
 # This module defines:
 #
-#   - udunits::udunits    - The udunits shared library and include directory, all in a single target.
-#   - udunits_SHARED_LIB  - The library
-#   - udunits_INCLUDE_DIR - The include directory
+#   - udunits::udunits       - The udunits shared library and include directory, all in a single target.
+#   - udunits_FOUND          - True if udunits was found
+#   - udunits_INCLUDE_DIR    - The include directory
+#   - udunits_LIBRARY        - The library
+#   - udunits_LIBRARY_SHARED - Whether the library is shared or not
 #
 # The following paths will be searched in order if set in CMake (first priority) or environment (second priority):
 #
@@ -24,24 +26,32 @@ find_path (
 	HINTS ${UDUNITS2_INCLUDE_DIRS} $ENV{UDUNITS2_INCLUDE_DIRS}
 		${UDUNITS2_ROOT} $ENV{UDUNITS2_ROOT}
 		${UDUNITS2_PATH} $ENV{UDUNITS2_PATH}
-	DOC "Path to udunits2.h"
-	)
-find_library(udunits_SHARED_LIB
+  PATH_SUFFIXES include include/udunits2
+	DOC "Path to udunits2.h" )
+
+find_library(udunits_LIBRARY
 	NAMES udunits2 udunits
 	HINTS ${UDUNITS2_LIBRARIES} $ENV{UDUNITS2_LIBRARIES}
 		${UDUNITS2_ROOT} $ENV{UDUNITS2_ROOT}
 		${UDUNITS2_PATH} $ENV{UDUNITS2_PATH}
-	DOC "Path to libudunits"
-	)
+  PATH_SUFFIXES lib64 lib
+	DOC "Path to libudunits library" )
+
+# We need to support both static and shared libraries
+if (udunits_LIBRARY MATCHES ".*\\.a$")
+  set(udunits_LIBRARY_SHARED FALSE)
+else()
+  set(udunits_LIBRARY_SHARED TRUE)
+endif()
 
 include (FindPackageHandleStandardArgs)
-find_package_handle_standard_args (udunits DEFAULT_MSG udunits_SHARED_LIB udunits_INCLUDE_DIR)
+find_package_handle_standard_args (udunits DEFAULT_MSG udunits_LIBRARY udunits_INCLUDE_DIR)
 
-mark_as_advanced (udunits_SHARED_LIB udunits_INCLUDE_DIR)
+mark_as_advanced (udunits_LIBRARY udunits_INCLUDE_DIR)
 
 if(udunits_FOUND AND NOT TARGET udunits::udunits)
 	add_library(udunits::udunits INTERFACE IMPORTED)
 	set_target_properties(udunits::udunits PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${udunits_INCLUDE_DIR})
-	set_target_properties(udunits::udunits PROPERTIES INTERFACE_LINK_LIBRARIES ${udunits_SHARED_LIB})
+  set_target_properties(udunits::udunits PROPERTIES INTERFACE_LINK_LIBRARIES ${udunits_LIBRARY})
 endif()
 

--- a/source/f_udunits_2.F90
+++ b/source/f_udunits_2.F90
@@ -1,5 +1,5 @@
 module f_udunits_2
-!    FORTRAN interface to the C library libudunits2
+!    Fortran interface to the C library libudunits2
 !    (currently modeled after version 2.0.4, but should work with subsequent versions)
 !        the C library libudunits2 is
 !            Copyright University Corporation for Atmospheric Research and contributors
@@ -35,7 +35,7 @@ module f_udunits_2
 !        Université du Québec à Montréal
 !        December 2021
 !
-!        a version of a FORTRAN 200x compliant compiler that supports
+!        a version of a Fortran 200x compliant compiler that supports
 !        use ISO_C_BINDING
 !        is needed
 !
@@ -46,14 +46,14 @@ module f_udunits_2
 !   see also :
 !   https://github.com/mfvalin/fortran_udunits2/blob/main/README.md
 !
-!        FORTRAN interface for function returning char * (ut_trim) not implemented
-!        one should use FORTRAN trim function (may not work in all cases)
+!        Fortran interface for function returning char * (ut_trim) not implemented
+!        one should use Fortran trim function (may not work in all cases)
 !
-!        FORTRAN interfaces to "visitor" functions are not implemented
+!        Fortran interfaces to "visitor" functions are not implemented
 !       ut_accept_visitor (const ut_unit* unit, const ut_visitor* visitor, void* arg)
 !       Data type: ut_visitor
 !
-!        FORTRAN interfaces to functions using a variable argument list and message handler
+!        Fortran interfaces to functions using a variable argument list and message handler
 !        are not implemented
 !    int ut_handle_error_message (const char* fmt, ...)
 !    ut_error_message_handler ut_set_error_message_handler (ut_error_message_handler handler)

--- a/source/f_udunits_2.F90
+++ b/source/f_udunits_2.F90
@@ -1,13 +1,13 @@
-    module f_udunits_2
-!    FORTRAN interface to the C library libudunits2 
+module f_udunits_2
+!    FORTRAN interface to the C library libudunits2
 !    (currently modeled after version 2.0.4, but should work with subsequent versions)
 !        the C library libudunits2 is
 !            Copyright University Corporation for Atmospheric Research and contributors
-!        this fortran Interface is is 
-!            Copyright Université du Québec à Montréal (UQAM) 2012-2021
+!        this fortran Interface is is
+!            Copyright UniversitÃ© du QuÃ©bec Ã  MontrÃ©al (UQAM) 2012-2021
 !     Redistribution and use in source and binary forms, with or without modification,
 !     are permitted provided that the following conditions are met:
-! 
+!
 !       1) Redistributions of source code must retain the above copyright notice,
 !           this list of conditions and the following disclaimer.
 !       2) Redistributions in binary form must reproduce the above copyright notice,
@@ -23,7 +23,7 @@
 !           infringes a patent. This termination provision shall not apply for an
 !           action alleging patent infringement by combinations of this software with
 !           other software or hardware.
-! 
+!
 !     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 !     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
 !     FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE CONTRIBUTORS
@@ -31,30 +31,30 @@
 !     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 !     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE SOFTWARE.
 !
-!	Michel Valin
-!	Université du Québec à Montréal
-!	December 2021
+!        Michel Valin
+!        UniversitÃ© du QuÃ©bec Ã  MontrÃ©al
+!        December 2021
 !
-!	a version of a FORTRAN 200x compliant compiler that supports
-!	use ISO_C_BINDING
-!	is needed
+!        a version of a FORTRAN 200x compliant compiler that supports
+!        use ISO_C_BINDING
+!        is needed
 !
-!	NOTES:
+!        NOTES:
 !
 !   documentation for the C code :
 !   https://www.unidata.ucar.edu/software/udunits/udunits-2.0.4/udunits2lib.html
 !   see also :
 !   https://github.com/mfvalin/fortran_udunits2/blob/main/README.md
 !
-!	FORTRAN interface for function returning char * (ut_trim) not implemented
-!	one should use FORTRAN trim function (may not work in all cases)
+!        FORTRAN interface for function returning char * (ut_trim) not implemented
+!        one should use FORTRAN trim function (may not work in all cases)
 !
-!	FORTRAN interfaces to "visitor" functions are not implemented
+!        FORTRAN interfaces to "visitor" functions are not implemented
 !       ut_accept_visitor (const ut_unit* unit, const ut_visitor* visitor, void* arg)
-!       Data type: ut_visitor 
-!	
-!	FORTRAN interfaces to functions using a variable argument list and message handler 
-!	are not implemented
+!       Data type: ut_visitor
+!
+!        FORTRAN interfaces to functions using a variable argument list and message handler
+!        are not implemented
 !    int ut_handle_error_message (const char* fmt, ...)
 !    ut_error_message_handler ut_set_error_message_handler (ut_error_message_handler handler)
 !    int ut_write_to_stderr (const char* fmt, va_list args)
@@ -62,1113 +62,1113 @@
 !    int ut_ignore (const char* fmt, va_list args)
 !    typedef int (*ut_error_message_handler)(const char* fmt, va_list args);
 !
-	use ISO_C_BINDING
-	implicit none
-	include 'f_udunits_2.inc'
+   use ISO_C_BINDING
+   implicit none
+   include 'f_udunits_2.inc'
 
-	interface
-    subroutine ut_ignore() bind(C,name='ut_ignore')
-    end subroutine ut_ignore
-    subroutine ut_write_to_stderr() bind(C,name='ut_write_to_stderr')
-    end subroutine ut_write_to_stderr
-    subroutine ut_set_error_message_handler(what) bind(C,name='ut_set_error_message_handler')
-      import :: C_FUNPTR
-      type(C_FUNPTR), value :: what
-    end subroutine ut_set_error_message_handler
-  end interface
+   interface
+      subroutine ut_ignore() bind(C, name='ut_ignore')
+      end subroutine ut_ignore
+      subroutine ut_write_to_stderr() bind(C, name='ut_write_to_stderr')
+      end subroutine ut_write_to_stderr
+      subroutine ut_set_error_message_handler(what) bind(C, name='ut_set_error_message_handler')
+         import :: C_FUNPTR
+         type(C_FUNPTR), value :: what
+      end subroutine ut_set_error_message_handler
+   end interface
 
-	interface UD_is_null
-	  module procedure UT_SYSTEM_PTR_is_null
-	  module procedure UT_UNIT_PTR_is_null
-	  module procedure CV_CONVERTER_PTR_is_null
-	  module procedure CHAR_STAR_is_null
-	end interface
+   interface UD_is_null
+      module procedure UT_SYSTEM_PTR_is_null
+      module procedure UT_UNIT_PTR_is_null
+      module procedure CV_CONVERTER_PTR_is_null
+      module procedure CHAR_STAR_is_null
+   end interface
 
-	contains
+contains
 !=============================================================================
-  logical function UT_SYSTEM_PTR_is_null(item)
-    use ISO_C_BINDING
-    implicit none
-    type(UT_SYSTEM_PTR), intent(IN) :: item
-    UT_SYSTEM_PTR_is_null = .not. C_ASSOCIATED(item%ptr)
-  end function UT_SYSTEM_PTR_is_null
+   logical function UT_SYSTEM_PTR_is_null(item)
+      use ISO_C_BINDING
+      implicit none
+      type(UT_SYSTEM_PTR), intent(IN) :: item
+      UT_SYSTEM_PTR_is_null = .not. C_ASSOCIATED(item%ptr)
+   end function UT_SYSTEM_PTR_is_null
 !=============================================================================
-  logical function UT_UNIT_PTR_is_null(item)
-    use ISO_C_BINDING
-    implicit none
-    type(UT_UNIT_PTR), intent(IN) :: item
-    UT_UNIT_PTR_is_null = .not. C_ASSOCIATED(item%ptr)
-  end function UT_UNIT_PTR_is_null
+   logical function UT_UNIT_PTR_is_null(item)
+      use ISO_C_BINDING
+      implicit none
+      type(UT_UNIT_PTR), intent(IN) :: item
+      UT_UNIT_PTR_is_null = .not. C_ASSOCIATED(item%ptr)
+   end function UT_UNIT_PTR_is_null
 !=============================================================================
-  logical function CV_CONVERTER_PTR_is_null(item)
-    use ISO_C_BINDING
-    implicit none
-    type(CV_CONVERTER_PTR), intent(IN) :: item
-    CV_CONVERTER_PTR_is_null = .not. C_ASSOCIATED(item%ptr)
-  end function CV_CONVERTER_PTR_is_null
+   logical function CV_CONVERTER_PTR_is_null(item)
+      use ISO_C_BINDING
+      implicit none
+      type(CV_CONVERTER_PTR), intent(IN) :: item
+      CV_CONVERTER_PTR_is_null = .not. C_ASSOCIATED(item%ptr)
+   end function CV_CONVERTER_PTR_is_null
 !=============================================================================
-  logical function CHAR_STAR_is_null(item)
-    use ISO_C_BINDING
-    implicit none
-    type(CHAR_STAR), intent(IN) :: item
-    CHAR_STAR_is_null = .not. ASSOCIATED(item%ptr)
-  end function CHAR_STAR_is_null
+   logical function CHAR_STAR_is_null(item)
+      use ISO_C_BINDING
+      implicit none
+      type(CHAR_STAR), intent(IN) :: item
+      CHAR_STAR_is_null = .not. ASSOCIATED(item%ptr)
+   end function CHAR_STAR_is_null
 !=============================================================================
-	type(UT_SYSTEM_PTR) function f_ut_read_xml(path)
-	use ISO_C_BINDING
-	implicit none
-	character (len=*), intent(IN) :: path
+   type(UT_SYSTEM_PTR) function f_ut_read_xml(path)
+      use ISO_C_BINDING
+      implicit none
+      character(len=*), intent(IN) :: path
 
-	character (len=1), dimension(len_trim(path)+1), target :: temp
+      character(len=1), dimension(len_trim(path) + 1), target :: temp
 
-	interface
-	type(C_PTR) function c_ut_read_xml(mypath) bind(C,name='ut_read_xml')
-	use ISO_C_BINDING
-	implicit none
-	type(C_PTR), value :: mypath
-	end function c_ut_read_xml
-	end interface
+      interface
+         type(C_PTR) function c_ut_read_xml(mypath) bind(C, name='ut_read_xml')
+            use ISO_C_BINDING
+            implicit none
+            type(C_PTR), value :: mypath
+         end function c_ut_read_xml
+      end interface
 
-	if(path == "" )then
-	  f_ut_read_xml%ptr = c_ut_read_xml(C_NULL_PTR)
-	else
-          temp = transfer( trim(path)//achar(0) , temp )
-	  f_ut_read_xml%ptr = c_ut_read_xml(c_loc(temp))
-	endif
+      if (path == "") then
+         f_ut_read_xml%ptr = c_ut_read_xml(C_NULL_PTR)
+      else
+         temp = transfer(trim(path)//achar(0), temp)
+         f_ut_read_xml%ptr = c_ut_read_xml(c_loc(temp))
+      end if
 
-	return
-	end function f_ut_read_xml
+      return
+   end function f_ut_read_xml
 !=============================================================================
-	type(UT_SYSTEM_PTR) function f_ut_new_system()
-	use ISO_C_BINDING
-	implicit none
+   type(UT_SYSTEM_PTR) function f_ut_new_system()
+      use ISO_C_BINDING
+      implicit none
 
-	interface
-	type(C_PTR) function c_ut_new_system() bind(C,name='ut_new_system')
-	use ISO_C_BINDING
-	implicit none
-	end function c_ut_new_system
-	end interface
+      interface
+         type(C_PTR) function c_ut_new_system() bind(C, name='ut_new_system')
+            use ISO_C_BINDING
+            implicit none
+         end function c_ut_new_system
+      end interface
 
-	f_ut_new_system%ptr = c_ut_new_system()
+      f_ut_new_system%ptr = c_ut_new_system()
 
-	end function f_ut_new_system
+   end function f_ut_new_system
 !=============================================================================
-	integer(C_INT) function f_ut_get_status()
-	use ISO_C_BINDING
-	implicit none
+   integer(C_INT) function f_ut_get_status()
+      use ISO_C_BINDING
+      implicit none
 
-	interface
-	integer(C_INT) function c_ut_get_status() bind(C,name='ut_get_status')
-	use ISO_C_BINDING
-	implicit none
-	end function c_ut_get_status
-	end interface
+      interface
+         integer(C_INT) function c_ut_get_status() bind(C, name='ut_get_status')
+            use ISO_C_BINDING
+            implicit none
+         end function c_ut_get_status
+      end interface
 
-	f_ut_get_status = c_ut_get_status()
+      f_ut_get_status = c_ut_get_status()
 
-	end function f_ut_get_status
+   end function f_ut_get_status
 !=============================================================================
-	subroutine f_ut_set_status(status)
-	use ISO_C_BINDING
-	implicit none
-	integer(C_INT), intent(IN) :: status
+   subroutine f_ut_set_status(status)
+      use ISO_C_BINDING
+      implicit none
+      integer(C_INT), intent(IN) :: status
 
-	interface
-	subroutine c_ut_set_status(status) bind(C,name='ut_set_status')
-	use ISO_C_BINDING
-	implicit none
-	integer(C_INT), value :: status
-	end subroutine c_ut_set_status
-	end interface
+      interface
+         subroutine c_ut_set_status(status) bind(C, name='ut_set_status')
+            use ISO_C_BINDING
+            implicit none
+            integer(C_INT), value :: status
+         end subroutine c_ut_set_status
+      end interface
 
-	call c_ut_set_status(status)
+      call c_ut_set_status(status)
 
-	end subroutine f_ut_set_status
+   end subroutine f_ut_set_status
 !=============================================================================
-	type(UT_SYSTEM_PTR) function f_ut_get_system(unit1)
-	use ISO_C_BINDING
-	implicit none
-	type(UT_UNIT_PTR), intent(IN) :: unit1
+   type(UT_SYSTEM_PTR) function f_ut_get_system(unit1)
+      use ISO_C_BINDING
+      implicit none
+      type(UT_UNIT_PTR), intent(IN) :: unit1
 
-	interface
-	type(C_PTR) function c_ut_get_system(unit1) bind(C,name='ut_get_system')
-	use ISO_C_BINDING
-	implicit none
-	type(C_PTR), value :: unit1
-	end function c_ut_get_system
-	end interface
+      interface
+         type(C_PTR) function c_ut_get_system(unit1) bind(C, name='ut_get_system')
+            use ISO_C_BINDING
+            implicit none
+            type(C_PTR), value :: unit1
+         end function c_ut_get_system
+      end interface
 
-	f_ut_get_system%ptr = c_ut_get_system(unit1%ptr)
+      f_ut_get_system%ptr = c_ut_get_system(unit1%ptr)
 
-	end function f_ut_get_system
+   end function f_ut_get_system
 !=============================================================================
-	type(UT_UNIT_PTR) function f_ut_new_base_unit(ut_system)
-	use ISO_C_BINDING
-	implicit none
-	type(UT_SYSTEM_PTR), intent(IN) :: ut_system
+   type(UT_UNIT_PTR) function f_ut_new_base_unit(ut_system)
+      use ISO_C_BINDING
+      implicit none
+      type(UT_SYSTEM_PTR), intent(IN) :: ut_system
 
-	interface
-	type(C_PTR) function c_ut_new_base_unit(system) bind(C,name='ut_new_base_unit')
-	use ISO_C_BINDING
-	implicit none
-	type(C_PTR), value :: system
-        end function c_ut_new_base_unit
-	end interface
+      interface
+         type(C_PTR) function c_ut_new_base_unit(system) bind(C, name='ut_new_base_unit')
+            use ISO_C_BINDING
+            implicit none
+            type(C_PTR), value :: system
+         end function c_ut_new_base_unit
+      end interface
 
-	f_ut_new_base_unit%ptr = c_ut_new_base_unit(ut_system%ptr)
-	return
-	end function f_ut_new_base_unit
+      f_ut_new_base_unit%ptr = c_ut_new_base_unit(ut_system%ptr)
+      return
+   end function f_ut_new_base_unit
 !=============================================================================
-	type(UT_UNIT_PTR) function f_ut_new_dimensionless_unit(ut_system)
-	use ISO_C_BINDING
-	implicit none
-	type(UT_SYSTEM_PTR), intent(IN) :: ut_system
+   type(UT_UNIT_PTR) function f_ut_new_dimensionless_unit(ut_system)
+      use ISO_C_BINDING
+      implicit none
+      type(UT_SYSTEM_PTR), intent(IN) :: ut_system
 
-	interface
-	type(C_PTR) function c_ut_new_dimensionless_unit(system) bind(C,name='ut_new_dimensionless_unit')
-	use ISO_C_BINDING
-	implicit none
-	type(C_PTR), value :: system
-        end function c_ut_new_dimensionless_unit
-	end interface
+      interface
+         type(C_PTR) function c_ut_new_dimensionless_unit(system) bind(C, name='ut_new_dimensionless_unit')
+            use ISO_C_BINDING
+            implicit none
+            type(C_PTR), value :: system
+         end function c_ut_new_dimensionless_unit
+      end interface
 
-	f_ut_new_dimensionless_unit%ptr = c_ut_new_dimensionless_unit(ut_system%ptr)
-	return
-	end function f_ut_new_dimensionless_unit
+      f_ut_new_dimensionless_unit%ptr = c_ut_new_dimensionless_unit(ut_system%ptr)
+      return
+   end function f_ut_new_dimensionless_unit
 !=============================================================================
-	type(UT_UNIT_PTR) function f_ut_get_dimensionless_unit_one(ut_system)
-	use ISO_C_BINDING
-	implicit none
-	type(UT_SYSTEM_PTR), intent(IN) :: ut_system
+   type(UT_UNIT_PTR) function f_ut_get_dimensionless_unit_one(ut_system)
+      use ISO_C_BINDING
+      implicit none
+      type(UT_SYSTEM_PTR), intent(IN) :: ut_system
 
-	interface
-	type(C_PTR) function c_ut_get_dimensionless_unit_one(system) bind(C,name='ut_get_dimensionless_unit_one')
-	use ISO_C_BINDING
-	implicit none
-	type(C_PTR), value :: system
-        end function c_ut_get_dimensionless_unit_one
-	end interface
+      interface
+         type(C_PTR) function c_ut_get_dimensionless_unit_one(system) bind(C, name='ut_get_dimensionless_unit_one')
+            use ISO_C_BINDING
+            implicit none
+            type(C_PTR), value :: system
+         end function c_ut_get_dimensionless_unit_one
+      end interface
 
-	f_ut_get_dimensionless_unit_one%ptr = c_ut_get_dimensionless_unit_one(ut_system%ptr)
-	return
-	end function f_ut_get_dimensionless_unit_one
+      f_ut_get_dimensionless_unit_one%ptr = c_ut_get_dimensionless_unit_one(ut_system%ptr)
+      return
+   end function f_ut_get_dimensionless_unit_one
 !=============================================================================
-	subroutine f_ut_free_system(ut_system)
-	use ISO_C_BINDING
-	implicit none
-	type(UT_SYSTEM_PTR), intent(IN) :: ut_system
+   subroutine f_ut_free_system(ut_system)
+      use ISO_C_BINDING
+      implicit none
+      type(UT_SYSTEM_PTR), intent(IN) :: ut_system
 
-	interface
-	subroutine c_ut_free_system(system) bind(C,name='ut_free_system')
-	use ISO_C_BINDING
-	implicit none
-	type(C_PTR), value :: system
-        end subroutine c_ut_free_system
-	end interface
+      interface
+         subroutine c_ut_free_system(system) bind(C, name='ut_free_system')
+            use ISO_C_BINDING
+            implicit none
+            type(C_PTR), value :: system
+         end subroutine c_ut_free_system
+      end interface
 
-	call c_ut_free_system(ut_system%ptr)
-	return
-	end subroutine f_ut_free_system
+      call c_ut_free_system(ut_system%ptr)
+      return
+   end subroutine f_ut_free_system
 !=============================================================================
-	type(UT_UNIT_PTR) function f_ut_get_unit_by_name(ut_system,name)
-	use ISO_C_BINDING
-	implicit none
-	type(UT_SYSTEM_PTR), intent(IN) :: ut_system
-	character (len=*), intent(IN) :: name
+   type(UT_UNIT_PTR) function f_ut_get_unit_by_name(ut_system, name)
+      use ISO_C_BINDING
+      implicit none
+      type(UT_SYSTEM_PTR), intent(IN) :: ut_system
+      character(len=*), intent(IN) :: name
 
-	character (len=1), dimension(len_trim(name)+1), target :: temp
+      character(len=1), dimension(len_trim(name) + 1), target :: temp
 
-	interface
-	type(C_PTR) function c_ut_get_unit_by_name(ut_system,name) bind(C,name='ut_get_unit_by_name')
-	use ISO_C_BINDING
-	implicit none
-	type(C_PTR), value :: ut_system
-	type(C_PTR), value :: name
-	end function c_ut_get_unit_by_name
-	end interface
+      interface
+         type(C_PTR) function c_ut_get_unit_by_name(ut_system, name) bind(C, name='ut_get_unit_by_name')
+            use ISO_C_BINDING
+            implicit none
+            type(C_PTR), value :: ut_system
+            type(C_PTR), value :: name
+         end function c_ut_get_unit_by_name
+      end interface
 
-	temp = transfer( trim(name)//achar(0) , temp )
-	f_ut_get_unit_by_name%ptr = c_ut_get_unit_by_name(ut_system%ptr,c_loc(temp))
+      temp = transfer(trim(name)//achar(0), temp)
+      f_ut_get_unit_by_name%ptr = c_ut_get_unit_by_name(ut_system%ptr, c_loc(temp))
 
-	end function f_ut_get_unit_by_name
+   end function f_ut_get_unit_by_name
 !=============================================================================
-	type(UT_UNIT_PTR) function f_ut_get_unit_by_symbol(ut_system,symbol)
-	use ISO_C_BINDING
-	implicit none
-	type(UT_SYSTEM_PTR), intent(IN) :: ut_system
-	character (len=*), intent(IN) :: symbol
+   type(UT_UNIT_PTR) function f_ut_get_unit_by_symbol(ut_system, symbol)
+      use ISO_C_BINDING
+      implicit none
+      type(UT_SYSTEM_PTR), intent(IN) :: ut_system
+      character(len=*), intent(IN) :: symbol
 
-	character (len=1), dimension(len_trim(symbol)+1), target :: temp
+      character(len=1), dimension(len_trim(symbol) + 1), target :: temp
 
-	interface
-	type(C_PTR) function c_ut_get_unit_by_symbol(ut_system,symbol) bind(C,name='ut_get_unit_by_symbol')
-	use ISO_C_BINDING
-	implicit none
-	type(C_PTR), value :: ut_system
-	type(C_PTR), value :: symbol
-	end function c_ut_get_unit_by_symbol
-	end interface
+      interface
+         type(C_PTR) function c_ut_get_unit_by_symbol(ut_system, symbol) bind(C, name='ut_get_unit_by_symbol')
+            use ISO_C_BINDING
+            implicit none
+            type(C_PTR), value :: ut_system
+            type(C_PTR), value :: symbol
+         end function c_ut_get_unit_by_symbol
+      end interface
 
-	temp = transfer( trim(symbol)//achar(0) , temp )
-	f_ut_get_unit_by_symbol%ptr = c_ut_get_unit_by_symbol(ut_system%ptr,c_loc(temp))
+      temp = transfer(trim(symbol)//achar(0), temp)
+      f_ut_get_unit_by_symbol%ptr = c_ut_get_unit_by_symbol(ut_system%ptr, c_loc(temp))
 
-	end function f_ut_get_unit_by_symbol
+   end function f_ut_get_unit_by_symbol
 !=============================================================================
-	integer(C_INT) function f_ut_map_name_to_unit(symbol,encoding,ut_unit)
-	use ISO_C_BINDING
-	implicit none
-	character (len=*), intent(IN) :: symbol
-	integer(C_INT), intent(IN) :: encoding
-	type(UT_UNIT_PTR), intent(IN) :: ut_unit
+   integer(C_INT) function f_ut_map_name_to_unit(symbol, encoding, ut_unit)
+      use ISO_C_BINDING
+      implicit none
+      character(len=*), intent(IN) :: symbol
+      integer(C_INT), intent(IN) :: encoding
+      type(UT_UNIT_PTR), intent(IN) :: ut_unit
 
-	character (len=1), dimension(len_trim(symbol)+1), target :: temp
+      character(len=1), dimension(len_trim(symbol) + 1), target :: temp
 
-	interface
-	integer(C_INT) function c_ut_map_name_to_unit(symbol,encoding,ut_unit) bind(C,name='ut_map_name_to_unit')
-	use ISO_C_BINDING
-	implicit none
-	type(C_PTR), value :: symbol
-	integer(C_INT), value :: encoding
-	type(C_PTR), value :: ut_unit
-	end function c_ut_map_name_to_unit
-	end interface
+      interface
+         integer(C_INT) function c_ut_map_name_to_unit(symbol, encoding, ut_unit) bind(C, name='ut_map_name_to_unit')
+            use ISO_C_BINDING
+            implicit none
+            type(C_PTR), value :: symbol
+            integer(C_INT), value :: encoding
+            type(C_PTR), value :: ut_unit
+         end function c_ut_map_name_to_unit
+      end interface
 
-	temp = transfer( trim(symbol)//achar(0) , temp )
-	f_ut_map_name_to_unit = c_ut_map_name_to_unit(c_loc(temp),encoding,ut_unit%ptr)
+      temp = transfer(trim(symbol)//achar(0), temp)
+      f_ut_map_name_to_unit = c_ut_map_name_to_unit(c_loc(temp), encoding, ut_unit%ptr)
 
-	end function f_ut_map_name_to_unit
+   end function f_ut_map_name_to_unit
 !=============================================================================
-	integer(C_INT) function f_ut_map_unit_to_name(ut_unit,symbol,encoding)
-	use ISO_C_BINDING
-	implicit none
-	type(UT_UNIT_PTR), intent(IN) :: ut_unit
-	character (len=*), intent(IN) :: symbol
-	integer(C_INT), intent(IN) :: encoding
+   integer(C_INT) function f_ut_map_unit_to_name(ut_unit, symbol, encoding)
+      use ISO_C_BINDING
+      implicit none
+      type(UT_UNIT_PTR), intent(IN) :: ut_unit
+      character(len=*), intent(IN) :: symbol
+      integer(C_INT), intent(IN) :: encoding
 
-	character (len=1), dimension(len_trim(symbol)+1), target :: temp
+      character(len=1), dimension(len_trim(symbol) + 1), target :: temp
 
-	interface
-	integer(C_INT) function c_ut_map_unit_to_name(ut_unit,symbol,encoding) bind(C,name='ut_map_unit_to_name')
-	use ISO_C_BINDING
-	implicit none
-	type(C_PTR), value :: ut_unit
-	type(C_PTR), value :: symbol
-	integer(C_INT), value :: encoding
-	end function c_ut_map_unit_to_name
-	end interface
+      interface
+         integer(C_INT) function c_ut_map_unit_to_name(ut_unit, symbol, encoding) bind(C, name='ut_map_unit_to_name')
+            use ISO_C_BINDING
+            implicit none
+            type(C_PTR), value :: ut_unit
+            type(C_PTR), value :: symbol
+            integer(C_INT), value :: encoding
+         end function c_ut_map_unit_to_name
+      end interface
 
-	temp = transfer( trim(symbol)//achar(0) , temp )
-	f_ut_map_unit_to_name = c_ut_map_unit_to_name(ut_unit%ptr,c_loc(temp),encoding)
+      temp = transfer(trim(symbol)//achar(0), temp)
+      f_ut_map_unit_to_name = c_ut_map_unit_to_name(ut_unit%ptr, c_loc(temp), encoding)
 
-	end function f_ut_map_unit_to_name
+   end function f_ut_map_unit_to_name
 !=============================================================================
-	integer(C_INT) function f_ut_unmap_name_to_unit(ut_system,symbol,encoding)
-	use ISO_C_BINDING
-	implicit none
-	type(UT_SYSTEM_PTR), intent(IN) :: ut_system
-	character (len=*), intent(IN) :: symbol
-	integer(C_INT), intent(IN) :: encoding
+   integer(C_INT) function f_ut_unmap_name_to_unit(ut_system, symbol, encoding)
+      use ISO_C_BINDING
+      implicit none
+      type(UT_SYSTEM_PTR), intent(IN) :: ut_system
+      character(len=*), intent(IN) :: symbol
+      integer(C_INT), intent(IN) :: encoding
 
-	character (len=1), dimension(len_trim(symbol)+1), target :: temp
+      character(len=1), dimension(len_trim(symbol) + 1), target :: temp
 
-	interface
-	integer(C_INT) function c_ut_unmap_name_to_unit(ut_system,symbol,encoding) bind(C,name='ut_unmap_name_to_unit')
-	use ISO_C_BINDING
-	implicit none
-	type(C_PTR), value :: ut_system
-	type(C_PTR), value :: symbol
-	integer(C_INT), value :: encoding
-	end function c_ut_unmap_name_to_unit
-	end interface
+      interface
+         integer(C_INT) function c_ut_unmap_name_to_unit(ut_system, symbol, encoding) bind(C, name='ut_unmap_name_to_unit')
+            use ISO_C_BINDING
+            implicit none
+            type(C_PTR), value :: ut_system
+            type(C_PTR), value :: symbol
+            integer(C_INT), value :: encoding
+         end function c_ut_unmap_name_to_unit
+      end interface
 
-	temp = transfer( trim(symbol)//achar(0) , temp )
-	f_ut_unmap_name_to_unit = c_ut_unmap_name_to_unit(ut_system%ptr,c_loc(temp),encoding)
+      temp = transfer(trim(symbol)//achar(0), temp)
+      f_ut_unmap_name_to_unit = c_ut_unmap_name_to_unit(ut_system%ptr, c_loc(temp), encoding)
 
-	end function f_ut_unmap_name_to_unit
+   end function f_ut_unmap_name_to_unit
 !=============================================================================
-	integer(C_INT) function f_ut_unmap_unit_to_name(ut_unit,encoding)
-	use ISO_C_BINDING
-	implicit none
-	type(UT_UNIT_PTR), intent(IN) :: ut_unit
-	integer(C_INT), intent(IN) :: encoding
+   integer(C_INT) function f_ut_unmap_unit_to_name(ut_unit, encoding)
+      use ISO_C_BINDING
+      implicit none
+      type(UT_UNIT_PTR), intent(IN) :: ut_unit
+      integer(C_INT), intent(IN) :: encoding
 
-	interface
-	integer(C_INT) function c_ut_unmap_unit_to_name(ut_unit,encoding) bind(C,name='ut_unmap_unit_to_name')
-	use ISO_C_BINDING
-	implicit none
-	type(C_PTR), value :: ut_unit
-	integer(C_INT), value :: encoding
-	end function c_ut_unmap_unit_to_name
-	end interface
+      interface
+         integer(C_INT) function c_ut_unmap_unit_to_name(ut_unit, encoding) bind(C, name='ut_unmap_unit_to_name')
+            use ISO_C_BINDING
+            implicit none
+            type(C_PTR), value :: ut_unit
+            integer(C_INT), value :: encoding
+         end function c_ut_unmap_unit_to_name
+      end interface
 
-	f_ut_unmap_unit_to_name = c_ut_unmap_unit_to_name(ut_unit%ptr,encoding)
+      f_ut_unmap_unit_to_name = c_ut_unmap_unit_to_name(ut_unit%ptr, encoding)
 
-	end function f_ut_unmap_unit_to_name
+   end function f_ut_unmap_unit_to_name
 !=============================================================================
-	integer(C_INT) function f_ut_map_symbol_to_unit(symbol,encoding,ut_unit)
-	use ISO_C_BINDING
-	implicit none
-	character (len=*), intent(IN) :: symbol
-	integer(C_INT), intent(IN) :: encoding
-	type(UT_UNIT_PTR), intent(IN) :: ut_unit
+   integer(C_INT) function f_ut_map_symbol_to_unit(symbol, encoding, ut_unit)
+      use ISO_C_BINDING
+      implicit none
+      character(len=*), intent(IN) :: symbol
+      integer(C_INT), intent(IN) :: encoding
+      type(UT_UNIT_PTR), intent(IN) :: ut_unit
 
-	character (len=1), dimension(len_trim(symbol)+1), target :: temp
+      character(len=1), dimension(len_trim(symbol) + 1), target :: temp
 
-	interface
-	integer(C_INT) function c_ut_map_symbol_to_unit(symbol,encoding,ut_unit) bind(C,name='ut_map_symbol_to_unit')
-	use ISO_C_BINDING
-	implicit none
-	type(C_PTR), value :: symbol
-	integer(C_INT), value :: encoding
-	type(C_PTR), value :: ut_unit
-	end function c_ut_map_symbol_to_unit
-	end interface
+      interface
+         integer(C_INT) function c_ut_map_symbol_to_unit(symbol, encoding, ut_unit) bind(C, name='ut_map_symbol_to_unit')
+            use ISO_C_BINDING
+            implicit none
+            type(C_PTR), value :: symbol
+            integer(C_INT), value :: encoding
+            type(C_PTR), value :: ut_unit
+         end function c_ut_map_symbol_to_unit
+      end interface
 
-	temp = transfer( trim(symbol)//achar(0) , temp )
-	f_ut_map_symbol_to_unit = c_ut_map_symbol_to_unit(c_loc(temp),encoding,ut_unit%ptr)
+      temp = transfer(trim(symbol)//achar(0), temp)
+      f_ut_map_symbol_to_unit = c_ut_map_symbol_to_unit(c_loc(temp), encoding, ut_unit%ptr)
 
-	end function f_ut_map_symbol_to_unit
+   end function f_ut_map_symbol_to_unit
 !=============================================================================
-	integer(C_INT) function f_ut_map_unit_to_symbol(ut_unit,symbol,encoding)
-	use ISO_C_BINDING
-	implicit none
-	type(UT_UNIT_PTR), intent(IN) :: ut_unit
-	character (len=*), intent(IN) :: symbol
-	integer(C_INT), intent(IN) :: encoding
+   integer(C_INT) function f_ut_map_unit_to_symbol(ut_unit, symbol, encoding)
+      use ISO_C_BINDING
+      implicit none
+      type(UT_UNIT_PTR), intent(IN) :: ut_unit
+      character(len=*), intent(IN) :: symbol
+      integer(C_INT), intent(IN) :: encoding
 
-	character (len=1), dimension(len_trim(symbol)+1), target :: temp
+      character(len=1), dimension(len_trim(symbol) + 1), target :: temp
 
-	interface
-	integer(C_INT) function c_ut_map_unit_to_symbol(ut_unit,symbol,encoding) bind(C,name='ut_map_unit_to_symbol')
-	use ISO_C_BINDING
-	implicit none
-	type(C_PTR), value :: ut_unit
-	type(C_PTR), value :: symbol
-	integer(C_INT), value :: encoding
-	end function c_ut_map_unit_to_symbol
-	end interface
+      interface
+         integer(C_INT) function c_ut_map_unit_to_symbol(ut_unit, symbol, encoding) bind(C, name='ut_map_unit_to_symbol')
+            use ISO_C_BINDING
+            implicit none
+            type(C_PTR), value :: ut_unit
+            type(C_PTR), value :: symbol
+            integer(C_INT), value :: encoding
+         end function c_ut_map_unit_to_symbol
+      end interface
 
-	temp = transfer( trim(symbol)//achar(0) , temp )
-	f_ut_map_unit_to_symbol = c_ut_map_unit_to_symbol(ut_unit%ptr,c_loc(temp),encoding)
+      temp = transfer(trim(symbol)//achar(0), temp)
+      f_ut_map_unit_to_symbol = c_ut_map_unit_to_symbol(ut_unit%ptr, c_loc(temp), encoding)
 
-	end function f_ut_map_unit_to_symbol
+   end function f_ut_map_unit_to_symbol
 !=============================================================================
-	integer(C_INT) function f_ut_unmap_symbol_to_unit(ut_system,symbol,encoding)
-	use ISO_C_BINDING
-	implicit none
-	type(UT_SYSTEM_PTR), intent(IN) :: ut_system
-	character (len=*), intent(IN) :: symbol
-	integer(C_INT), intent(IN) :: encoding
+   integer(C_INT) function f_ut_unmap_symbol_to_unit(ut_system, symbol, encoding)
+      use ISO_C_BINDING
+      implicit none
+      type(UT_SYSTEM_PTR), intent(IN) :: ut_system
+      character(len=*), intent(IN) :: symbol
+      integer(C_INT), intent(IN) :: encoding
 
-	character (len=1), dimension(len_trim(symbol)+1), target :: temp
+      character(len=1), dimension(len_trim(symbol) + 1), target :: temp
 
-	interface
-	integer(C_INT) function c_ut_unmap_symbol_to_unit(ut_system,symbol,encoding) bind(C,name='ut_unmap_symbol_to_unit')
-	use ISO_C_BINDING
-	implicit none
-	type(C_PTR), value :: ut_system
-	type(C_PTR), value :: symbol
-	integer(C_INT), value :: encoding
-	end function c_ut_unmap_symbol_to_unit
-	end interface
+      interface
+         integer(C_INT) function c_ut_unmap_symbol_to_unit(ut_system, symbol, encoding) bind(C, name='ut_unmap_symbol_to_unit')
+            use ISO_C_BINDING
+            implicit none
+            type(C_PTR), value :: ut_system
+            type(C_PTR), value :: symbol
+            integer(C_INT), value :: encoding
+         end function c_ut_unmap_symbol_to_unit
+      end interface
 
-	temp = transfer( trim(symbol)//achar(0) , temp )
-	f_ut_unmap_symbol_to_unit = c_ut_unmap_symbol_to_unit(ut_system%ptr,c_loc(temp),encoding)
+      temp = transfer(trim(symbol)//achar(0), temp)
+      f_ut_unmap_symbol_to_unit = c_ut_unmap_symbol_to_unit(ut_system%ptr, c_loc(temp), encoding)
 
-	end function f_ut_unmap_symbol_to_unit
+   end function f_ut_unmap_symbol_to_unit
 !=============================================================================
-	integer(C_INT) function f_ut_unmap_unit_to_symbol(ut_unit,encoding)
-	use ISO_C_BINDING
-	implicit none
-	type(UT_UNIT_PTR), intent(IN) :: ut_unit
-	integer(C_INT), intent(IN) :: encoding
+   integer(C_INT) function f_ut_unmap_unit_to_symbol(ut_unit, encoding)
+      use ISO_C_BINDING
+      implicit none
+      type(UT_UNIT_PTR), intent(IN) :: ut_unit
+      integer(C_INT), intent(IN) :: encoding
 
-	interface
-	integer(C_INT) function c_ut_unmap_unit_to_symbol(ut_unit,encoding) bind(C,name='ut_unmap_unit_to_symbol')
-	use ISO_C_BINDING
-	implicit none
-	type(C_PTR), value :: ut_unit
-	integer(C_INT), value :: encoding
-	end function c_ut_unmap_unit_to_symbol
-	end interface
+      interface
+         integer(C_INT) function c_ut_unmap_unit_to_symbol(ut_unit, encoding) bind(C, name='ut_unmap_unit_to_symbol')
+            use ISO_C_BINDING
+            implicit none
+            type(C_PTR), value :: ut_unit
+            integer(C_INT), value :: encoding
+         end function c_ut_unmap_unit_to_symbol
+      end interface
 
-	f_ut_unmap_unit_to_symbol = c_ut_unmap_unit_to_symbol(ut_unit%ptr,encoding)
+      f_ut_unmap_unit_to_symbol = c_ut_unmap_unit_to_symbol(ut_unit%ptr, encoding)
 
-	end function f_ut_unmap_unit_to_symbol
+   end function f_ut_unmap_unit_to_symbol
 !=============================================================================
-	integer(C_INT) function f_ut_set_second(unit1)
-	use ISO_C_BINDING
-	implicit none
-	type(UT_UNIT_PTR), intent(IN) :: unit1
+   integer(C_INT) function f_ut_set_second(unit1)
+      use ISO_C_BINDING
+      implicit none
+      type(UT_UNIT_PTR), intent(IN) :: unit1
 
-	interface
-	integer(C_INT) function c_ut_set_second(unit1) bind(C,name='ut_set_second')
-	use ISO_C_BINDING
-	implicit none
-	type(C_PTR), value :: unit1
-	end function c_ut_set_second
-	end interface
+      interface
+         integer(C_INT) function c_ut_set_second(unit1) bind(C, name='ut_set_second')
+            use ISO_C_BINDING
+            implicit none
+            type(C_PTR), value :: unit1
+         end function c_ut_set_second
+      end interface
 
-	f_ut_set_second = c_ut_set_second(unit1%ptr)
+      f_ut_set_second = c_ut_set_second(unit1%ptr)
 
-	end function f_ut_set_second
+   end function f_ut_set_second
 !=============================================================================
-	integer(C_INT) function f_ut_add_name_prefix(ut_system,name,value)
-	use ISO_C_BINDING
-	implicit none
-	type(UT_SYSTEM_PTR), intent(IN) :: ut_system
-	character (len=*), intent(IN) :: name
-	real(C_DOUBLE), intent(IN) :: value
+   integer(C_INT) function f_ut_add_name_prefix(ut_system, name, value)
+      use ISO_C_BINDING
+      implicit none
+      type(UT_SYSTEM_PTR), intent(IN) :: ut_system
+      character(len=*), intent(IN) :: name
+      real(C_DOUBLE), intent(IN) :: value
 
-	character (len=1), dimension(len_trim(name)+1), target :: temp
+      character(len=1), dimension(len_trim(name) + 1), target :: temp
 
-	interface
-	integer(C_INT) function c_ut_add_name_prefix(ut_system,name,value) bind(C,name='ut_add_name_prefix')
-	use ISO_C_BINDING
-	implicit none
-	type(C_PTR), value :: ut_system
-	type(C_PTR), value :: name
-	real(C_DOUBLE), value :: value
-	end function c_ut_add_name_prefix
-	end interface
+      interface
+         integer(C_INT) function c_ut_add_name_prefix(ut_system, name, value) bind(C, name='ut_add_name_prefix')
+            use ISO_C_BINDING
+            implicit none
+            type(C_PTR), value :: ut_system
+            type(C_PTR), value :: name
+            real(C_DOUBLE), value :: value
+         end function c_ut_add_name_prefix
+      end interface
 
-	temp = transfer( trim(name)//achar(0) , temp )
-	f_ut_add_name_prefix = c_ut_add_name_prefix(ut_system%ptr,c_loc(temp),value)
+      temp = transfer(trim(name)//achar(0), temp)
+      f_ut_add_name_prefix = c_ut_add_name_prefix(ut_system%ptr, c_loc(temp), value)
 
-	end function f_ut_add_name_prefix
+   end function f_ut_add_name_prefix
 !=============================================================================
-	integer(C_INT) function f_ut_add_symbol_prefix(ut_system,name,value)
-	use ISO_C_BINDING
-	implicit none
-	type(UT_SYSTEM_PTR), intent(IN) :: ut_system
-	character (len=*), intent(IN) :: name
-	real(C_DOUBLE), intent(IN) :: value
+   integer(C_INT) function f_ut_add_symbol_prefix(ut_system, name, value)
+      use ISO_C_BINDING
+      implicit none
+      type(UT_SYSTEM_PTR), intent(IN) :: ut_system
+      character(len=*), intent(IN) :: name
+      real(C_DOUBLE), intent(IN) :: value
 
-	character (len=1), dimension(len_trim(name)+1), target :: temp
+      character(len=1), dimension(len_trim(name) + 1), target :: temp
 
-	interface
-	integer(C_INT) function c_ut_add_symbol_prefix(ut_system,name,value) bind(C,name='ut_add_symbol_prefix')
-	use ISO_C_BINDING
-	implicit none
-	type(C_PTR), value :: ut_system
-	type(C_PTR), value :: name
-	real(C_DOUBLE), value :: value
-	end function c_ut_add_symbol_prefix
-	end interface
+      interface
+         integer(C_INT) function c_ut_add_symbol_prefix(ut_system, name, value) bind(C, name='ut_add_symbol_prefix')
+            use ISO_C_BINDING
+            implicit none
+            type(C_PTR), value :: ut_system
+            type(C_PTR), value :: name
+            real(C_DOUBLE), value :: value
+         end function c_ut_add_symbol_prefix
+      end interface
 
-	temp = transfer( trim(name)//achar(0) , temp )
-	f_ut_add_symbol_prefix = c_ut_add_symbol_prefix(ut_system%ptr,c_loc(temp),value)
+      temp = transfer(trim(name)//achar(0), temp)
+      f_ut_add_symbol_prefix = c_ut_add_symbol_prefix(ut_system%ptr, c_loc(temp), value)
 
-	end function f_ut_add_symbol_prefix
+   end function f_ut_add_symbol_prefix
 !=============================================================================
-	type(UT_UNIT_PTR) function f_ut_offset_by_time(unit1,origin)
-	use ISO_C_BINDING
-	implicit none
-	type(UT_UNIT_PTR), intent(IN) :: unit1
-	real(C_DOUBLE), intent(IN) :: origin
+   type(UT_UNIT_PTR) function f_ut_offset_by_time(unit1, origin)
+      use ISO_C_BINDING
+      implicit none
+      type(UT_UNIT_PTR), intent(IN) :: unit1
+      real(C_DOUBLE), intent(IN) :: origin
 
-	interface
-	type(C_PTR) function c_ut_offset_by_time(unit1,origin) bind(C,name='ut_offset_by_time')
-	use ISO_C_BINDING
-	implicit none
-	type(C_PTR), value :: unit1
-	real(C_DOUBLE), value :: origin
-	end function c_ut_offset_by_time
-	end interface
+      interface
+         type(C_PTR) function c_ut_offset_by_time(unit1, origin) bind(C, name='ut_offset_by_time')
+            use ISO_C_BINDING
+            implicit none
+            type(C_PTR), value :: unit1
+            real(C_DOUBLE), value :: origin
+         end function c_ut_offset_by_time
+      end interface
 
-	f_ut_offset_by_time%ptr = c_ut_offset_by_time(unit1%ptr,origin)
+      f_ut_offset_by_time%ptr = c_ut_offset_by_time(unit1%ptr, origin)
 
-	end function f_ut_offset_by_time
+   end function f_ut_offset_by_time
 !=============================================================================
-	integer function f_ut_format(ut_unit,buffer,options)
-	use ISO_C_BINDING
-	implicit none
-	type(UT_UNIT_PTR), intent(IN) :: ut_unit
-	character (len=*), intent(OUT) :: buffer
-	integer, intent(IN) :: options
+   integer function f_ut_format(ut_unit, buffer, options)
+      use ISO_C_BINDING
+      implicit none
+      type(UT_UNIT_PTR), intent(IN) :: ut_unit
+      character(len=*), intent(OUT) :: buffer
+      integer, intent(IN) :: options
 
-	integer(C_SIZE_T) :: buflen
-	character (len=1), dimension(len(buffer)), target :: temp
-	integer(C_INT) :: opt
-	integer :: blen
+      integer(C_SIZE_T) :: buflen
+      character(len=1), dimension(len(buffer)), target :: temp
+      integer(C_INT) :: opt
+      integer :: blen
 
-	interface
-	integer(C_INT) function c_ut_format(ut_unit,buffer,buflen,options)  bind(C,name='ut_format')
-	use ISO_C_BINDING
-	type(C_PTR), value :: ut_unit
-	type(C_PTR), value :: buffer
-	integer(C_SIZE_T), value :: buflen
-	integer(C_INT), value :: options
-	end function c_ut_format
-	end interface
+      interface
+         integer(C_INT) function c_ut_format(ut_unit, buffer, buflen, options) bind(C, name='ut_format')
+            use ISO_C_BINDING
+            type(C_PTR), value :: ut_unit
+            type(C_PTR), value :: buffer
+            integer(C_SIZE_T), value :: buflen
+            integer(C_INT), value :: options
+         end function c_ut_format
+      end interface
 
-	buflen=len(buffer)
-	opt = options
-	temp=" "
-	blen = c_ut_format(ut_unit%ptr,c_loc(temp),buflen,opt)
-	f_ut_format = blen
-	if(blen <= 0) then
-	  buffer="ERROR"
-	  return
-	endif
-	buffer = ""
-!	do i=1,blen
-!	  buffer(i:i)=temp(i)
-!	enddo
-	buffer(1:blen)=transfer(temp(1:blen),buffer)
+      buflen = len(buffer)
+      opt = options
+      temp = " "
+      blen = c_ut_format(ut_unit%ptr, c_loc(temp), buflen, opt)
+      f_ut_format = blen
+      if (blen <= 0) then
+         buffer = "ERROR"
+         return
+      end if
+      buffer = ""
+!        do i=1,blen
+!          buffer(i:i)=temp(i)
+!        enddo
+      buffer(1:blen) = transfer(temp(1:blen), buffer)
 
-	end function f_ut_format
+   end function f_ut_format
 !=============================================================================
-	type(UT_UNIT_PTR) function f_ut_parse(ut_system,symbol,charset)
-	use ISO_C_BINDING
-	implicit none
-	type(UT_SYSTEM_PTR), intent(IN) :: ut_system
-	character (len=*), intent(IN) :: symbol
-	integer, intent(IN) :: charset  ! ignored for the time being
+   type(UT_UNIT_PTR) function f_ut_parse(ut_system, symbol, charset)
+      use ISO_C_BINDING
+      implicit none
+      type(UT_SYSTEM_PTR), intent(IN) :: ut_system
+      character(len=*), intent(IN) :: symbol
+      integer, intent(IN) :: charset  ! ignored for the time being
 
-	integer(C_INT) :: encoding
-	character (len=1), dimension(len_trim(symbol)+1), target :: temp
+      integer(C_INT) :: encoding
+      character(len=1), dimension(len_trim(symbol) + 1), target :: temp
 
-	interface
-	type(C_PTR) function c_ut_parse(ut_system,symbol,encoding) bind(C,name='ut_parse')
-	use ISO_C_BINDING
-	implicit none
-	type(C_PTR), value :: ut_system
-	type(C_PTR), value :: symbol
-	integer(C_INT), value :: encoding
-	end function c_ut_parse
-	end interface
+      interface
+         type(C_PTR) function c_ut_parse(ut_system, symbol, encoding) bind(C, name='ut_parse')
+            use ISO_C_BINDING
+            implicit none
+            type(C_PTR), value :: ut_system
+            type(C_PTR), value :: symbol
+            integer(C_INT), value :: encoding
+         end function c_ut_parse
+      end interface
 
-!	encoding = UT_ASCII
-	encoding = charset
-	temp = transfer( trim(symbol)//achar(0) , temp )
-	f_ut_parse%ptr = c_ut_parse(ut_system%ptr,c_loc(temp),encoding)
+!        encoding = UT_ASCII
+      encoding = charset
+      temp = transfer(trim(symbol)//achar(0), temp)
+      f_ut_parse%ptr = c_ut_parse(ut_system%ptr, c_loc(temp), encoding)
 
-	end function f_ut_parse
+   end function f_ut_parse
 !=============================================================================
-	subroutine f_ut_free(ut_unit)
-	use ISO_C_BINDING
-	implicit none
-	type(UT_UNIT_PTR), intent(IN) :: ut_unit
+   subroutine f_ut_free(ut_unit)
+      use ISO_C_BINDING
+      implicit none
+      type(UT_UNIT_PTR), intent(IN) :: ut_unit
 
-	interface
-	subroutine c_ut_free(ut_unit) bind(C,name='ut_free')
-	use ISO_C_BINDING
-	implicit none
-	type(C_PTR), value :: ut_unit
-        end subroutine c_ut_free
-	end interface
+      interface
+         subroutine c_ut_free(ut_unit) bind(C, name='ut_free')
+            use ISO_C_BINDING
+            implicit none
+            type(C_PTR), value :: ut_unit
+         end subroutine c_ut_free
+      end interface
 
-	call c_ut_free(ut_unit%ptr)
-	return
-	end subroutine f_ut_free
+      call c_ut_free(ut_unit%ptr)
+      return
+   end subroutine f_ut_free
 !=============================================================================
-	integer function f_ut_compare(unit1,unit2)
-	use ISO_C_BINDING
-	implicit none
-	type(UT_UNIT_PTR), intent(IN) :: unit1,unit2
+   integer function f_ut_compare(unit1, unit2)
+      use ISO_C_BINDING
+      implicit none
+      type(UT_UNIT_PTR), intent(IN) :: unit1, unit2
 
-	interface
-	integer(C_INT) function c_ut_compare(unit1,unit2) bind(C,name='ut_compare')
-	use ISO_C_BINDING
-	implicit none
-	type(C_PTR), value :: unit1
-	type(C_PTR), value :: unit2
-	end function c_ut_compare
-	end interface
+      interface
+         integer(C_INT) function c_ut_compare(unit1, unit2) bind(C, name='ut_compare')
+            use ISO_C_BINDING
+            implicit none
+            type(C_PTR), value :: unit1
+            type(C_PTR), value :: unit2
+         end function c_ut_compare
+      end interface
 
-	f_ut_compare = c_ut_compare(unit1%ptr,unit2%ptr)
+      f_ut_compare = c_ut_compare(unit1%ptr, unit2%ptr)
 
-	end function f_ut_compare
+   end function f_ut_compare
 !=============================================================================
-	logical function f_ut_same_system(unit1,unit2)
-	use ISO_C_BINDING
-	implicit none
-	type(UT_UNIT_PTR), intent(IN) :: unit1,unit2
+   logical function f_ut_same_system(unit1, unit2)
+      use ISO_C_BINDING
+      implicit none
+      type(UT_UNIT_PTR), intent(IN) :: unit1, unit2
 
-	interface
-	integer(C_INT) function c_ut_same_system(unit1,unit2) bind(C,name='ut_same_system')
-	use ISO_C_BINDING
-	implicit none
-	type(C_PTR), value :: unit1
-	type(C_PTR), value :: unit2
-	end function c_ut_same_system
-	end interface
+      interface
+         integer(C_INT) function c_ut_same_system(unit1, unit2) bind(C, name='ut_same_system')
+            use ISO_C_BINDING
+            implicit none
+            type(C_PTR), value :: unit1
+            type(C_PTR), value :: unit2
+         end function c_ut_same_system
+      end interface
 
-	f_ut_same_system = c_ut_same_system(unit1%ptr,unit2%ptr) .ne. 0
+      f_ut_same_system = c_ut_same_system(unit1%ptr, unit2%ptr) .ne. 0
 
-	end function f_ut_same_system
+   end function f_ut_same_system
 !=============================================================================
-	logical function f_ut_is_dimensionless(unit1)
-	use ISO_C_BINDING
-	implicit none
-	type(UT_UNIT_PTR), intent(IN) :: unit1
+   logical function f_ut_is_dimensionless(unit1)
+      use ISO_C_BINDING
+      implicit none
+      type(UT_UNIT_PTR), intent(IN) :: unit1
 
-	interface
-	integer(C_INT) function c_ut_is_dimensionless(unit1) bind(C,name='ut_is_dimensionless')
-	use ISO_C_BINDING
-	implicit none
-	type(C_PTR), value :: unit1
-	end function c_ut_is_dimensionless
-	end interface
+      interface
+         integer(C_INT) function c_ut_is_dimensionless(unit1) bind(C, name='ut_is_dimensionless')
+            use ISO_C_BINDING
+            implicit none
+            type(C_PTR), value :: unit1
+         end function c_ut_is_dimensionless
+      end interface
 
-	f_ut_is_dimensionless = c_ut_is_dimensionless(unit1%ptr) .ne. 0
+      f_ut_is_dimensionless = c_ut_is_dimensionless(unit1%ptr) .ne. 0
 
-	end function f_ut_is_dimensionless
+   end function f_ut_is_dimensionless
 !=============================================================================
-	logical function f_ut_are_convertible(unit1,unit2)
-	use ISO_C_BINDING
-	implicit none
-	type(UT_UNIT_PTR), intent(IN) :: unit1,unit2
+   logical function f_ut_are_convertible(unit1, unit2)
+      use ISO_C_BINDING
+      implicit none
+      type(UT_UNIT_PTR), intent(IN) :: unit1, unit2
 
-	interface
-	integer(C_INT) function c_ut_are_convertible(unit1,unit2) bind(C,name='ut_are_convertible')
-	use ISO_C_BINDING
-	implicit none
-	type(C_PTR), value :: unit1
-	type(C_PTR), value :: unit2
-	end function c_ut_are_convertible
-	end interface
+      interface
+         integer(C_INT) function c_ut_are_convertible(unit1, unit2) bind(C, name='ut_are_convertible')
+            use ISO_C_BINDING
+            implicit none
+            type(C_PTR), value :: unit1
+            type(C_PTR), value :: unit2
+         end function c_ut_are_convertible
+      end interface
 
-	f_ut_are_convertible = c_ut_are_convertible(unit1%ptr,unit2%ptr) .ne. 0
+      f_ut_are_convertible = c_ut_are_convertible(unit1%ptr, unit2%ptr) .ne. 0
 
-	end function f_ut_are_convertible
+   end function f_ut_are_convertible
 !=============================================================================
-	type(UT_UNIT_PTR) function f_ut_root(unit1,base)
-	use ISO_C_BINDING
-	implicit none
-	type(UT_UNIT_PTR), intent(IN) :: unit1
-	integer(C_INT), intent(IN) :: base
+   type(UT_UNIT_PTR) function f_ut_root(unit1, base)
+      use ISO_C_BINDING
+      implicit none
+      type(UT_UNIT_PTR), intent(IN) :: unit1
+      integer(C_INT), intent(IN) :: base
 
-	interface
-	type(C_PTR) function c_ut_root(unit1,base) bind(C,name='ut_root')
-	use ISO_C_BINDING
-	implicit none
-	type(C_PTR), value :: unit1
-	integer(C_INT), value :: base
-	end function c_ut_root
-	end interface
+      interface
+         type(C_PTR) function c_ut_root(unit1, base) bind(C, name='ut_root')
+            use ISO_C_BINDING
+            implicit none
+            type(C_PTR), value :: unit1
+            integer(C_INT), value :: base
+         end function c_ut_root
+      end interface
 
-	f_ut_root%ptr = c_ut_root(unit1%ptr,base)
+      f_ut_root%ptr = c_ut_root(unit1%ptr, base)
 
-	end function f_ut_root
+   end function f_ut_root
 !=============================================================================
-	type(UT_UNIT_PTR) function f_ut_raise(unit1,base)
-	use ISO_C_BINDING
-	implicit none
-	type(UT_UNIT_PTR), intent(IN) :: unit1
-	integer(C_INT), intent(IN) :: base
+   type(UT_UNIT_PTR) function f_ut_raise(unit1, base)
+      use ISO_C_BINDING
+      implicit none
+      type(UT_UNIT_PTR), intent(IN) :: unit1
+      integer(C_INT), intent(IN) :: base
 
-	interface
-	type(C_PTR) function c_ut_raise(unit1,base) bind(C,name='ut_raise')
-	use ISO_C_BINDING
-	implicit none
-	type(C_PTR), value :: unit1
-	integer(C_INT), value :: base
-	end function c_ut_raise
-	end interface
+      interface
+         type(C_PTR) function c_ut_raise(unit1, base) bind(C, name='ut_raise')
+            use ISO_C_BINDING
+            implicit none
+            type(C_PTR), value :: unit1
+            integer(C_INT), value :: base
+         end function c_ut_raise
+      end interface
 
-	f_ut_raise%ptr = c_ut_raise(unit1%ptr,base)
+      f_ut_raise%ptr = c_ut_raise(unit1%ptr, base)
 
-	end function f_ut_raise
+   end function f_ut_raise
 !=============================================================================
-	type(UT_UNIT_PTR) function f_ut_offset(unit1,base)
-	use ISO_C_BINDING
-	implicit none
-	type(UT_UNIT_PTR), intent(IN) :: unit1
-	real(C_DOUBLE), intent(IN) :: base
+   type(UT_UNIT_PTR) function f_ut_offset(unit1, base)
+      use ISO_C_BINDING
+      implicit none
+      type(UT_UNIT_PTR), intent(IN) :: unit1
+      real(C_DOUBLE), intent(IN) :: base
 
-	interface
-	type(C_PTR) function c_ut_offset(unit1,base) bind(C,name='ut_offset')
-	use ISO_C_BINDING
-	implicit none
-	type(C_PTR), value :: unit1
-	real(C_DOUBLE), value :: base
-	end function c_ut_offset
-	end interface
+      interface
+         type(C_PTR) function c_ut_offset(unit1, base) bind(C, name='ut_offset')
+            use ISO_C_BINDING
+            implicit none
+            type(C_PTR), value :: unit1
+            real(C_DOUBLE), value :: base
+         end function c_ut_offset
+      end interface
 
-	f_ut_offset%ptr = c_ut_offset(unit1%ptr,base)
+      f_ut_offset%ptr = c_ut_offset(unit1%ptr, base)
 
-	end function f_ut_offset
+   end function f_ut_offset
 !=============================================================================
-	type(UT_UNIT_PTR) function f_ut_scale(base,unit1)
-	use ISO_C_BINDING
-	implicit none
-	type(UT_UNIT_PTR), intent(IN) :: unit1
-	real(C_DOUBLE), intent(IN) :: base
+   type(UT_UNIT_PTR) function f_ut_scale(base, unit1)
+      use ISO_C_BINDING
+      implicit none
+      type(UT_UNIT_PTR), intent(IN) :: unit1
+      real(C_DOUBLE), intent(IN) :: base
 
-	interface
-	type(C_PTR) function c_ut_scale(base,unit1) bind(C,name='ut_scale')
-	use ISO_C_BINDING
-	implicit none
-	type(C_PTR), value :: unit1
-	real(C_DOUBLE), value :: base
-	end function c_ut_scale
-	end interface
+      interface
+         type(C_PTR) function c_ut_scale(base, unit1) bind(C, name='ut_scale')
+            use ISO_C_BINDING
+            implicit none
+            type(C_PTR), value :: unit1
+            real(C_DOUBLE), value :: base
+         end function c_ut_scale
+      end interface
 
-	f_ut_scale%ptr = c_ut_scale(base,unit1%ptr)
+      f_ut_scale%ptr = c_ut_scale(base, unit1%ptr)
 
-	end function f_ut_scale
+   end function f_ut_scale
 !=============================================================================
-	type(UT_UNIT_PTR) function f_ut_log(base,unit1)
-	use ISO_C_BINDING
-	implicit none
-	type(UT_UNIT_PTR), intent(IN) :: unit1
-	real(C_DOUBLE), intent(IN) :: base
+   type(UT_UNIT_PTR) function f_ut_log(base, unit1)
+      use ISO_C_BINDING
+      implicit none
+      type(UT_UNIT_PTR), intent(IN) :: unit1
+      real(C_DOUBLE), intent(IN) :: base
 
-	interface
-	type(C_PTR) function c_ut_log(base,unit1) bind(C,name='ut_log')
-	use ISO_C_BINDING
-	implicit none
-	type(C_PTR), value :: unit1
-	real(C_DOUBLE), value :: base
-	end function c_ut_log
-	end interface
+      interface
+         type(C_PTR) function c_ut_log(base, unit1) bind(C, name='ut_log')
+            use ISO_C_BINDING
+            implicit none
+            type(C_PTR), value :: unit1
+            real(C_DOUBLE), value :: base
+         end function c_ut_log
+      end interface
 
-	f_ut_log%ptr = c_ut_log(base,unit1%ptr)
+      f_ut_log%ptr = c_ut_log(base, unit1%ptr)
 
-	end function f_ut_log
+   end function f_ut_log
 !=============================================================================
-	type(UT_UNIT_PTR) function f_ut_clone(unit1)
-	use ISO_C_BINDING
-	implicit none
-	type(UT_UNIT_PTR), intent(IN) :: unit1
+   type(UT_UNIT_PTR) function f_ut_clone(unit1)
+      use ISO_C_BINDING
+      implicit none
+      type(UT_UNIT_PTR), intent(IN) :: unit1
 
-	interface
-	type(C_PTR) function c_ut_clone(unit1) bind(C,name='ut_clone')
-	use ISO_C_BINDING
-	implicit none
-	type(C_PTR), value :: unit1
-	end function c_ut_clone
-	end interface
+      interface
+         type(C_PTR) function c_ut_clone(unit1) bind(C, name='ut_clone')
+            use ISO_C_BINDING
+            implicit none
+            type(C_PTR), value :: unit1
+         end function c_ut_clone
+      end interface
 
-	f_ut_clone%ptr = c_ut_clone(unit1%ptr)
+      f_ut_clone%ptr = c_ut_clone(unit1%ptr)
 
-	end function f_ut_clone
+   end function f_ut_clone
 !=============================================================================
-	type(UT_UNIT_PTR) function f_ut_invert(unit1)
-	use ISO_C_BINDING
-	implicit none
-	type(UT_UNIT_PTR), intent(IN) :: unit1
+   type(UT_UNIT_PTR) function f_ut_invert(unit1)
+      use ISO_C_BINDING
+      implicit none
+      type(UT_UNIT_PTR), intent(IN) :: unit1
 
-	interface
-	type(C_PTR) function c_ut_invert(unit1) bind(C,name='ut_invert')
-	use ISO_C_BINDING
-	implicit none
-	type(C_PTR), value :: unit1
-	end function c_ut_invert
-	end interface
+      interface
+         type(C_PTR) function c_ut_invert(unit1) bind(C, name='ut_invert')
+            use ISO_C_BINDING
+            implicit none
+            type(C_PTR), value :: unit1
+         end function c_ut_invert
+      end interface
 
-	f_ut_invert%ptr = c_ut_invert(unit1%ptr)
+      f_ut_invert%ptr = c_ut_invert(unit1%ptr)
 
-	end function f_ut_invert
+   end function f_ut_invert
 !=============================================================================
-	type(UT_UNIT_PTR) function f_ut_multiply(unit1,unit2)
-	use ISO_C_BINDING
-	implicit none
-	type(UT_UNIT_PTR), intent(IN) :: unit1,unit2
+   type(UT_UNIT_PTR) function f_ut_multiply(unit1, unit2)
+      use ISO_C_BINDING
+      implicit none
+      type(UT_UNIT_PTR), intent(IN) :: unit1, unit2
 
-	interface
-	type(C_PTR) function c_ut_multiply(unit1,unit2) bind(C,name='ut_multiply')
-	use ISO_C_BINDING
-	implicit none
-	type(C_PTR), value :: unit1
-	type(C_PTR), value :: unit2
-	end function c_ut_multiply
-	end interface
+      interface
+         type(C_PTR) function c_ut_multiply(unit1, unit2) bind(C, name='ut_multiply')
+            use ISO_C_BINDING
+            implicit none
+            type(C_PTR), value :: unit1
+            type(C_PTR), value :: unit2
+         end function c_ut_multiply
+      end interface
 
-	f_ut_multiply%ptr = c_ut_multiply(unit1%ptr,unit2%ptr)
+      f_ut_multiply%ptr = c_ut_multiply(unit1%ptr, unit2%ptr)
 
-	end function f_ut_multiply
+   end function f_ut_multiply
 !=============================================================================
-	type(UT_UNIT_PTR) function f_ut_divide(unit1,unit2)
-	use ISO_C_BINDING
-	implicit none
-	type(UT_UNIT_PTR), intent(IN) :: unit1,unit2
+   type(UT_UNIT_PTR) function f_ut_divide(unit1, unit2)
+      use ISO_C_BINDING
+      implicit none
+      type(UT_UNIT_PTR), intent(IN) :: unit1, unit2
 
-	interface
-	type(C_PTR) function ut_divide(unit1,unit2) bind(C,name='ut_divide')
-	use ISO_C_BINDING
-	implicit none
-	type(C_PTR), value :: unit1
-	type(C_PTR), value :: unit2
-	end function ut_divide
-	end interface
+      interface
+         type(C_PTR) function ut_divide(unit1, unit2) bind(C, name='ut_divide')
+            use ISO_C_BINDING
+            implicit none
+            type(C_PTR), value :: unit1
+            type(C_PTR), value :: unit2
+         end function ut_divide
+      end interface
 
-	f_ut_divide%ptr = ut_divide(unit1%ptr,unit2%ptr)
+      f_ut_divide%ptr = ut_divide(unit1%ptr, unit2%ptr)
 
-	end function f_ut_divide
+   end function f_ut_divide
 !=============================================================================
-	type(CV_CONVERTER_PTR) function f_ut_get_converter(from,to)
-	use ISO_C_BINDING
-	implicit none
-	type(UT_UNIT_PTR), intent(IN) :: from, to
+   type(CV_CONVERTER_PTR) function f_ut_get_converter(from, to)
+      use ISO_C_BINDING
+      implicit none
+      type(UT_UNIT_PTR), intent(IN) :: from, to
 
-	interface
-	type(C_PTR) function ut_get_converter(from,to) bind(C,name='ut_get_converter')
-	use ISO_C_BINDING
-	implicit none
-	type(C_PTR), value :: from
-	type(C_PTR), value :: to
-	end function ut_get_converter
-	end interface
+      interface
+         type(C_PTR) function ut_get_converter(from, to) bind(C, name='ut_get_converter')
+            use ISO_C_BINDING
+            implicit none
+            type(C_PTR), value :: from
+            type(C_PTR), value :: to
+         end function ut_get_converter
+      end interface
 
-	f_ut_get_converter%ptr = ut_get_converter(from%ptr,to%ptr)
+      f_ut_get_converter%ptr = ut_get_converter(from%ptr, to%ptr)
 
-	end function f_ut_get_converter
+   end function f_ut_get_converter
 !=============================================================================
-	subroutine f_cv_free(converter)
-	use ISO_C_BINDING
-	implicit none
-	type(CV_CONVERTER_PTR), intent(IN) :: converter
+   subroutine f_cv_free(converter)
+      use ISO_C_BINDING
+      implicit none
+      type(CV_CONVERTER_PTR), intent(IN) :: converter
 
-	interface
-	subroutine cv_free(converter) bind(C,name='cv_free')
-	use ISO_C_BINDING
-	implicit none
-	type(C_PTR), value :: converter
-        end subroutine cv_free
-	end interface
+      interface
+         subroutine cv_free(converter) bind(C, name='cv_free')
+            use ISO_C_BINDING
+            implicit none
+            type(C_PTR), value :: converter
+         end subroutine cv_free
+      end interface
 
-	call cv_free(converter%ptr)
-	return
-	end subroutine f_cv_free
+      call cv_free(converter%ptr)
+      return
+   end subroutine f_cv_free
 !=============================================================================
-	real function f_cv_convert_float(converter,what)
-	use ISO_C_BINDING
-	implicit none
-	type(CV_CONVERTER_PTR), intent(IN) :: converter
-	real(C_FLOAT), intent(IN) :: what
+   real function f_cv_convert_float(converter, what)
+      use ISO_C_BINDING
+      implicit none
+      type(CV_CONVERTER_PTR), intent(IN) :: converter
+      real(C_FLOAT), intent(IN) :: what
 
-	interface
-	real(C_FLOAT) function cv_convert_float(converter,what) bind(C,name='cv_convert_float')
-	use ISO_C_BINDING
-	implicit none
-	type(C_PTR), value :: converter
-	real(C_FLOAT), value :: what
-	end function
-	end interface
+      interface
+         real(C_FLOAT) function cv_convert_float(converter, what) bind(C, name='cv_convert_float')
+            use ISO_C_BINDING
+            implicit none
+            type(C_PTR), value :: converter
+            real(C_FLOAT), value :: what
+         end function
+      end interface
 
-	f_cv_convert_float = cv_convert_float(converter%ptr,what)
+      f_cv_convert_float = cv_convert_float(converter%ptr, what)
 
-	end function f_cv_convert_float
+   end function f_cv_convert_float
 !=============================================================================
-	real(C_DOUBLE) function f_cv_convert_double(converter,what)
-	use ISO_C_BINDING
-	implicit none
-	type(CV_CONVERTER_PTR), intent(IN) :: converter
-	real(C_DOUBLE), intent(IN) :: what
+   real(C_DOUBLE) function f_cv_convert_double(converter, what)
+      use ISO_C_BINDING
+      implicit none
+      type(CV_CONVERTER_PTR), intent(IN) :: converter
+      real(C_DOUBLE), intent(IN) :: what
 
-	interface
-	real(C_DOUBLE) function cv_convert_double(converter,what) bind(C,name='cv_convert_double')
-	use ISO_C_BINDING
-	implicit none
-	type(C_PTR), value :: converter
-	real(C_DOUBLE), value :: what
-	end function
-	end interface
+      interface
+         real(C_DOUBLE) function cv_convert_double(converter, what) bind(C, name='cv_convert_double')
+            use ISO_C_BINDING
+            implicit none
+            type(C_PTR), value :: converter
+            real(C_DOUBLE), value :: what
+         end function
+      end interface
 
-	f_cv_convert_double = cv_convert_double(converter%ptr,what)
+      f_cv_convert_double = cv_convert_double(converter%ptr, what)
 
-	end function f_cv_convert_double
+   end function f_cv_convert_double
 !=============================================================================
-	subroutine f_cv_convert_floats(converter,what,count,dest)
-	use ISO_C_BINDING
-	implicit none
-	type(CV_CONVERTER_PTR), intent(IN) :: converter
-	real(C_FLOAT), intent(IN), dimension(*) :: what
-	real(C_FLOAT), intent(OUT), dimension(*) :: dest
-	integer, intent(IN) :: count
+   subroutine f_cv_convert_floats(converter, what, count, dest)
+      use ISO_C_BINDING
+      implicit none
+      type(CV_CONVERTER_PTR), intent(IN) :: converter
+      real(C_FLOAT), intent(IN), dimension(*) :: what
+      real(C_FLOAT), intent(OUT), dimension(*) :: dest
+      integer, intent(IN) :: count
 
-	type(C_PTR) :: dummy
-	integer(C_SIZE_T) :: temp
+      type(C_PTR) :: dummy
+      integer(C_SIZE_T) :: temp
 
-	interface
-	type(C_PTR) function cv_convert_floats(converter,what,count,dest) bind(C,name='cv_convert_floats')
-	use ISO_C_BINDING
-	implicit none
-	type(C_PTR), value :: converter
-	real(C_FLOAT), intent(IN), dimension(*) :: what
-	real(C_FLOAT), intent(OUT), dimension(*) :: dest
-	integer(C_SIZE_T), value :: count
-	end function
-	end interface
+      interface
+         type(C_PTR) function cv_convert_floats(converter, what, count, dest) bind(C, name='cv_convert_floats')
+            use ISO_C_BINDING
+            implicit none
+            type(C_PTR), value :: converter
+            real(C_FLOAT), intent(IN), dimension(*) :: what
+            real(C_FLOAT), intent(OUT), dimension(*) :: dest
+            integer(C_SIZE_T), value :: count
+         end function
+      end interface
 
-	temp = count
-	dummy = cv_convert_floats(converter%ptr,what,temp,dest)
+      temp = count
+      dummy = cv_convert_floats(converter%ptr, what, temp, dest)
 
-	end subroutine f_cv_convert_floats
+   end subroutine f_cv_convert_floats
 !=============================================================================
-	subroutine f_cv_convert_doubles(converter,what,count,dest)
-	use ISO_C_BINDING
-	implicit none
-	type(CV_CONVERTER_PTR), intent(IN) :: converter
-	real(C_DOUBLE), intent(IN), dimension(*) :: what
-	real(C_DOUBLE), intent(OUT), dimension(*) :: dest
-	integer, intent(IN) :: count
+   subroutine f_cv_convert_doubles(converter, what, count, dest)
+      use ISO_C_BINDING
+      implicit none
+      type(CV_CONVERTER_PTR), intent(IN) :: converter
+      real(C_DOUBLE), intent(IN), dimension(*) :: what
+      real(C_DOUBLE), intent(OUT), dimension(*) :: dest
+      integer, intent(IN) :: count
 
-	type(C_PTR) :: dummy
-	integer(C_SIZE_T) :: temp
+      type(C_PTR) :: dummy
+      integer(C_SIZE_T) :: temp
 
-	interface
-	type(C_PTR) function cv_convert_doubles(converter,what,count,dest) bind(C,name='cv_convert_doubles')
-	use ISO_C_BINDING
-	implicit none
-	type(C_PTR), value :: converter
-	real(C_DOUBLE), intent(IN), dimension(*) :: what
-	real(C_DOUBLE), intent(OUT), dimension(*) :: dest
-	integer(C_SIZE_T), value :: count
-	end function
-	end interface
+      interface
+         type(C_PTR) function cv_convert_doubles(converter, what, count, dest) bind(C, name='cv_convert_doubles')
+            use ISO_C_BINDING
+            implicit none
+            type(C_PTR), value :: converter
+            real(C_DOUBLE), intent(IN), dimension(*) :: what
+            real(C_DOUBLE), intent(OUT), dimension(*) :: dest
+            integer(C_SIZE_T), value :: count
+         end function
+      end interface
 
-	temp = count
-	dummy = cv_convert_doubles(converter%ptr,what,temp,dest)
+      temp = count
+      dummy = cv_convert_doubles(converter%ptr, what, temp, dest)
 
-	end subroutine f_cv_convert_doubles
+   end subroutine f_cv_convert_doubles
 !=============================================================================
-	subroutine f_ut_decode_time(time,year,month,day,hour,mimute,second,resolution)
-	use ISO_C_BINDING
-	implicit none
-	real(C_DOUBLE), intent(IN) :: time
-	integer(C_INT) :: year,month,day,hour,mimute
-	real(C_DOUBLE) :: second, resolution
+   subroutine f_ut_decode_time(time, year, month, day, hour, mimute, second, resolution)
+      use ISO_C_BINDING
+      implicit none
+      real(C_DOUBLE), intent(IN) :: time
+      integer(C_INT) :: year, month, day, hour, mimute
+      real(C_DOUBLE) :: second, resolution
 
-	interface
-	subroutine c_ut_decode_time(time,year,month,day,hour,mimute,second,resolution) bind(C,name='ut_decode_time')
-	use ISO_C_BINDING
-	implicit none
-	real(C_DOUBLE), value :: time
-	integer(C_INT) :: year,month,day,hour,mimute
-	real(C_DOUBLE) :: second, resolution
-	end subroutine c_ut_decode_time
-	end interface
+      interface
+         subroutine c_ut_decode_time(time, year, month, day, hour, mimute, second, resolution) bind(C, name='ut_decode_time')
+            use ISO_C_BINDING
+            implicit none
+            real(C_DOUBLE), value :: time
+            integer(C_INT) :: year, month, day, hour, mimute
+            real(C_DOUBLE) :: second, resolution
+         end subroutine c_ut_decode_time
+      end interface
 
-	call c_ut_decode_time(time,year,month,day,hour,mimute,second,resolution)
+      call c_ut_decode_time(time, year, month, day, hour, mimute, second, resolution)
 
-	end subroutine f_ut_decode_time
+   end subroutine f_ut_decode_time
 !=============================================================================
-	real(C_DOUBLE) function f_ut_encode_time(year,month,day,hour,mimute,second)
-	use ISO_C_BINDING
-	implicit none
-	integer(C_INT), intent(IN) :: year,month,day,hour,mimute
-	real(C_DOUBLE), intent(IN) :: second
+   real(C_DOUBLE) function f_ut_encode_time(year, month, day, hour, mimute, second)
+      use ISO_C_BINDING
+      implicit none
+      integer(C_INT), intent(IN) :: year, month, day, hour, mimute
+      real(C_DOUBLE), intent(IN) :: second
 
-	interface
-	real(C_DOUBLE) function c_ut_encode_time(year,month,day,hour,mimute,second) bind(C,name='ut_encode_time')
-	use ISO_C_BINDING
-	implicit none
-	integer(C_INT), value :: year,month,day,hour,mimute
-	real(C_DOUBLE), value :: second
-	end function c_ut_encode_time
-	end interface
+      interface
+         real(C_DOUBLE) function c_ut_encode_time(year, month, day, hour, mimute, second) bind(C, name='ut_encode_time')
+            use ISO_C_BINDING
+            implicit none
+            integer(C_INT), value :: year, month, day, hour, mimute
+            real(C_DOUBLE), value :: second
+         end function c_ut_encode_time
+      end interface
 
-	f_ut_encode_time = c_ut_encode_time(year,month,day,hour,mimute,second)
+      f_ut_encode_time = c_ut_encode_time(year, month, day, hour, mimute, second)
 
-	end function f_ut_encode_time
+   end function f_ut_encode_time
 !=============================================================================
-	real(C_DOUBLE) function f_ut_encode_date(year,month,day)
-	use ISO_C_BINDING
-	implicit none
-	integer(C_INT), intent(IN) :: year,month,day
+   real(C_DOUBLE) function f_ut_encode_date(year, month, day)
+      use ISO_C_BINDING
+      implicit none
+      integer(C_INT), intent(IN) :: year, month, day
 
-	interface
-	real(C_DOUBLE) function c_ut_encode_date(year,month,day) bind(C,name='ut_encode_date')
-	use ISO_C_BINDING
-	implicit none
-	integer(C_INT), value :: year,month,day
-	end function c_ut_encode_date
-	end interface
+      interface
+         real(C_DOUBLE) function c_ut_encode_date(year, month, day) bind(C, name='ut_encode_date')
+            use ISO_C_BINDING
+            implicit none
+            integer(C_INT), value :: year, month, day
+         end function c_ut_encode_date
+      end interface
 
-	f_ut_encode_date = c_ut_encode_date(year,month,day)
+      f_ut_encode_date = c_ut_encode_date(year, month, day)
 
-	end function f_ut_encode_date
+   end function f_ut_encode_date
 !=============================================================================
-	real(C_DOUBLE) function f_ut_encode_clock(hour,mimute,second)
-	use ISO_C_BINDING
-	implicit none
-	integer(C_INT), intent(IN) :: hour,mimute
-	real(C_DOUBLE), intent(IN) :: second
+   real(C_DOUBLE) function f_ut_encode_clock(hour, mimute, second)
+      use ISO_C_BINDING
+      implicit none
+      integer(C_INT), intent(IN) :: hour, mimute
+      real(C_DOUBLE), intent(IN) :: second
 
-	interface
-	real(C_DOUBLE) function c_ut_encode_clock(hour,mimute,second) bind(C,name='ut_encode_clock')
-	use ISO_C_BINDING
-	implicit none
-	integer(C_INT), value :: hour,mimute
-	real(C_DOUBLE), value :: second
-	end function c_ut_encode_clock
-	end interface
+      interface
+         real(C_DOUBLE) function c_ut_encode_clock(hour, mimute, second) bind(C, name='ut_encode_clock')
+            use ISO_C_BINDING
+            implicit none
+            integer(C_INT), value :: hour, mimute
+            real(C_DOUBLE), value :: second
+         end function c_ut_encode_clock
+      end interface
 
-	f_ut_encode_clock = c_ut_encode_clock(hour,mimute,second)
+      f_ut_encode_clock = c_ut_encode_clock(hour, mimute, second)
 
-	end function f_ut_encode_clock
+   end function f_ut_encode_clock
 !=============================================================================
-    character(len=256) function f_ut_get_name(ut_unit,encoding)
-    use ISO_C_BINDING
-    implicit none
-    type(UT_UNIT_PTR), intent(IN) :: ut_unit
-    integer(C_INT), intent(IN) :: encoding
-    type(C_PTR) :: ptr
-    character(len=1), DIMENSION(:), pointer :: c_temp
-    character(len=256) :: s_temp
-    integer :: i
+   character(len=256) function f_ut_get_name(ut_unit, encoding)
+      use ISO_C_BINDING
+      implicit none
+      type(UT_UNIT_PTR), intent(IN) :: ut_unit
+      integer(C_INT), intent(IN) :: encoding
+      type(C_PTR) :: ptr
+      character(len=1), DIMENSION(:), pointer :: c_temp
+      character(len=256) :: s_temp
+      integer :: i
 
-    interface
-    type(C_PTR) function c_ut_get_name(ut_unit,encoding) bind(C,name='ut_get_name')
-    use ISO_C_BINDING
-    implicit none
-    type(C_PTR), value :: ut_unit
-    integer(C_INT), value :: encoding
-    end function c_ut_get_name
-    end interface
+      interface
+         type(C_PTR) function c_ut_get_name(ut_unit, encoding) bind(C, name='ut_get_name')
+            use ISO_C_BINDING
+            implicit none
+            type(C_PTR), value :: ut_unit
+            integer(C_INT), value :: encoding
+         end function c_ut_get_name
+      end interface
 
-    s_temp = ''
-    ptr = c_ut_get_name(ut_unit%ptr,encoding)
-    if(C_ASSOCIATED(ptr)) then
-      call c_f_pointer(ptr,c_temp,[256])
-      do i=1,256
-        if(c_temp(i) == achar(0)) exit
-        s_temp(i:i) = c_temp(i)
-      enddo
-    else
-      s_temp="NoName"
-    endif
-    f_ut_get_name = s_temp
+      s_temp = ''
+      ptr = c_ut_get_name(ut_unit%ptr, encoding)
+      if (C_ASSOCIATED(ptr)) then
+         call c_f_pointer(ptr, c_temp, [256])
+         do i = 1, 256
+            if (c_temp(i) == achar(0)) exit
+            s_temp(i:i) = c_temp(i)
+         end do
+      else
+         s_temp = "NoName"
+      end if
+      f_ut_get_name = s_temp
 
-    end function f_ut_get_name
+   end function f_ut_get_name
 !=============================================================================
-    character(len=256) function f_ut_get_symbol(ut_unit,encoding)
-    use ISO_C_BINDING
-    implicit none
-    type(UT_UNIT_PTR), intent(IN) :: ut_unit
-    integer(C_INT), intent(IN) :: encoding
-    type(C_PTR) :: ptr
-    character(len=1), DIMENSION(:), pointer :: c_temp
-    character(len=256) :: s_temp
-    integer :: i
+   character(len=256) function f_ut_get_symbol(ut_unit, encoding)
+      use ISO_C_BINDING
+      implicit none
+      type(UT_UNIT_PTR), intent(IN) :: ut_unit
+      integer(C_INT), intent(IN) :: encoding
+      type(C_PTR) :: ptr
+      character(len=1), DIMENSION(:), pointer :: c_temp
+      character(len=256) :: s_temp
+      integer :: i
 
-    interface
-    type(C_PTR) function c_ut_get_symbol(ut_unit,encoding) bind(C,name='ut_get_symbol')
-    use ISO_C_BINDING
-    implicit none
-    type(C_PTR), value :: ut_unit
-    integer(C_INT), value :: encoding
-    end function c_ut_get_symbol
-    end interface
+      interface
+         type(C_PTR) function c_ut_get_symbol(ut_unit, encoding) bind(C, name='ut_get_symbol')
+            use ISO_C_BINDING
+            implicit none
+            type(C_PTR), value :: ut_unit
+            integer(C_INT), value :: encoding
+         end function c_ut_get_symbol
+      end interface
 
-    s_temp = ''
-    ptr = c_ut_get_symbol(ut_unit%ptr,encoding)
-    if(C_ASSOCIATED(ptr)) then
-      call c_f_pointer(ptr,c_temp,[256])
-      do i=1,256
-        if(c_temp(i) == achar(0)) exit
-        s_temp(i:i) = c_temp(i)
-      enddo
-    else
-      s_temp="NoSymbol"
-    endif
-    f_ut_get_symbol = s_temp
+      s_temp = ''
+      ptr = c_ut_get_symbol(ut_unit%ptr, encoding)
+      if (C_ASSOCIATED(ptr)) then
+         call c_f_pointer(ptr, c_temp, [256])
+         do i = 1, 256
+            if (c_temp(i) == achar(0)) exit
+            s_temp(i:i) = c_temp(i)
+         end do
+      else
+         s_temp = "NoSymbol"
+      end if
+      f_ut_get_symbol = s_temp
 
-    end function f_ut_get_symbol
+   end function f_ut_get_symbol
 !=============================================================================
-	end module f_udunits_2
+end module f_udunits_2

--- a/source/f_udunits_2.inc
+++ b/source/f_udunits_2.inc
@@ -1,9 +1,9 @@
-!    FORTRAN interface to the C library udunits2 
+!    FORTRAN interface to the C library udunits2
 !        the C library udunits2 (C) is Copyright UCAR/Unidata
 !        this fortran Interface is (C) is Copyright Université du Québec à Montréal
 !     Redistribution and use in source and binary forms, with or without modification,
 !     are permitted provided that the following conditions are met:
-! 
+!
 !       1) Redistributions of source code must retain the above copyright notice,
 !           this list of conditions and the following disclaimer.
 !       2) Redistributions in binary form must reproduce the above copyright notice,
@@ -19,65 +19,65 @@
 !           infringes a patent. This termination provision shall not apply for an
 !           action alleging patent infringement by combinations of this software with
 !           other software or hardware.
-! 
+!
 !     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 !     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
 !     FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE CONTRIBUTORS
 !     OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
 !     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 !     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE SOFTWARE.
-! documentation for c code : 
+! documentation for c code :
 ! http://www.unidata.ucar.edu/software/udunits/udunits-2.0.4/udunits2lib.html
-	type, bind(C) :: UT_SYSTEM_PTR
-	type(C_PTR) :: ptr
-	end type
-	type(UT_SYSTEM_PTR), parameter :: UT_SYSTEM_PTR_NULL = UT_SYSTEM_PTR(C_NULL_PTR)
+        type, bind(C) :: UT_SYSTEM_PTR
+           type(C_PTR) :: ptr
+        end type
+        type(UT_SYSTEM_PTR), parameter :: UT_SYSTEM_PTR_NULL = UT_SYSTEM_PTR(C_NULL_PTR)
 
-	type, bind(C) :: UT_UNIT_PTR
-	type(C_PTR) :: ptr
-	end type
-	type(UT_UNIT_PTR), parameter ::UT_UNIT_PTR_NULL = UT_UNIT_PTR(C_NULL_PTR)
+        type, bind(C) :: UT_UNIT_PTR
+           type(C_PTR) :: ptr
+        end type
+        type(UT_UNIT_PTR), parameter ::UT_UNIT_PTR_NULL = UT_UNIT_PTR(C_NULL_PTR)
 
-	type, bind(C) :: CV_CONVERTER_PTR
-	type(C_PTR) :: ptr
-	end type
-	type(CV_CONVERTER_PTR), parameter ::CV_CONVERTER_PTR_NULL = CV_CONVERTER_PTR(C_NULL_PTR)
+        type, bind(C) :: CV_CONVERTER_PTR
+           type(C_PTR) :: ptr
+        end type
+        type(CV_CONVERTER_PTR), parameter ::CV_CONVERTER_PTR_NULL = CV_CONVERTER_PTR(C_NULL_PTR)
 
-	type, bind(C) :: UT_STATUS
-	integer(C_INT) :: value
-	end type
-	
-	type :: CHAR_STAR
-	character(len=1),dimension(:),pointer :: ptr
-	end type
-	type(CHAR_STAR), parameter ::CHAR_STAR_NULL = CHAR_STAR(NULL())
+        type, bind(C) :: UT_STATUS
+           integer(C_INT) :: value
+        end type
+
+        type :: CHAR_STAR
+           character(len=1), dimension(:), pointer :: ptr
+        end type
+        type(CHAR_STAR), parameter ::CHAR_STAR_NULL = CHAR_STAR(NULL())
 !
 !   the following constants are lifted from C enum in udunits2.h
 !   and may have to be adjusted should any change be made to that file
 !
 !   a cleaner way would be to use a C program to produce this file
 !
-	integer, parameter :: UT_ASCII = 0
-	integer, parameter :: UT_ISO_8859_1 = 1
-	integer, parameter :: UT_LATIN1 = UT_ISO_8859_1
-	integer, parameter :: UT_UTF8 = 2
+        integer, parameter :: UT_ASCII = 0
+        integer, parameter :: UT_ISO_8859_1 = 1
+        integer, parameter :: UT_LATIN1 = UT_ISO_8859_1
+        integer, parameter :: UT_UTF8 = 2
 
-	integer, parameter :: UT_NAMES = 4
-	integer, parameter :: UT_DEFINITION = 8
+        integer, parameter :: UT_NAMES = 4
+        integer, parameter :: UT_DEFINITION = 8
 
-	integer, parameter :: UT_SUCCESS  =0
-	integer, parameter :: UT_BAD_ARG  =1
-	integer, parameter :: UT_EXISTS  =2
-	integer, parameter :: UT_NO_UNIT  =3
-	integer, parameter :: UT_OS  =4
-	integer, parameter :: UT_NOT_SAME_SYSTEM  =5
-	integer, parameter :: UT_MEANINGLESS  =6
-	integer, parameter :: UT_NO_SECOND  =7
-	integer, parameter :: UT_VISIT_ERROR  =8
-	integer, parameter :: UT_CANT_FORMAT  =9
-	integer, parameter :: UT_SYNTAX  =10
-	integer, parameter :: UT_UNKNOWN  =11
-	integer, parameter :: UT_OPEN_ARG  =12
-	integer, parameter :: UT_OPEN_ENV  =13
-	integer, parameter :: UT_OPEN_DEFAULT  =14
-	integer, parameter :: UT_PARSE  =15
+        integer, parameter :: UT_SUCCESS = 0
+        integer, parameter :: UT_BAD_ARG = 1
+        integer, parameter :: UT_EXISTS = 2
+        integer, parameter :: UT_NO_UNIT = 3
+        integer, parameter :: UT_OS = 4
+        integer, parameter :: UT_NOT_SAME_SYSTEM = 5
+        integer, parameter :: UT_MEANINGLESS = 6
+        integer, parameter :: UT_NO_SECOND = 7
+        integer, parameter :: UT_VISIT_ERROR = 8
+        integer, parameter :: UT_CANT_FORMAT = 9
+        integer, parameter :: UT_SYNTAX = 10
+        integer, parameter :: UT_UNKNOWN = 11
+        integer, parameter :: UT_OPEN_ARG = 12
+        integer, parameter :: UT_OPEN_ENV = 13
+        integer, parameter :: UT_OPEN_DEFAULT = 14
+        integer, parameter :: UT_PARSE = 15

--- a/source/f_udunits_2.inc
+++ b/source/f_udunits_2.inc
@@ -1,4 +1,4 @@
-!    FORTRAN interface to the C library udunits2
+!    Fortran interface to the C library udunits2
 !        the C library udunits2 (C) is Copyright UCAR/Unidata
 !        this fortran Interface is (C) is Copyright Université du Québec à Montréal
 !     Redistribution and use in source and binary forms, with or without modification,

--- a/tests/test_f_udunits_2.F90
+++ b/tests/test_f_udunits_2.F90
@@ -1,198 +1,198 @@
-	program test_f_udunits_2  ! very rudimentary test program for libudunits2 Fortran nterface
+program test_f_udunits_2  ! very rudimentary test program for libudunits2 Fortran nterface
 !
 ! example of compilation and execution with gfortran (udunits2 installed in /opt/udunits2)
 ! test program in fortran_udunits2/tests, source code in fortran_udunits2/source
 ! gfortran -Wall  -Wno-tabs -I/opt/udunits2/include test_f_udunits_2.F90 -I../source -L/opt/udunits2/lib -ludunits2 -lexpat
 ! LD_LIBRARY_PATH=/opt/udunits2/lib ./a.out
 !
-	use f_udunits_2
-	implicit none
+   use f_udunits_2
+   implicit none
 
-	type(UT_SYSTEM_PTR) :: sys
-	type(CV_CONVERTER_PTR) :: conv1, conv2, conv3, time_cvt, time_cvt0
-	type(UT_UNIT_PTR) :: unit1, unit2, unit3, unit4, unit5
-	type(UT_UNIT_PTR) :: unit0, unit6, unit7, unit8, unit9, unit06
-	type(UT_UNIT_PTR) :: erg, watt, watt_s, sec, time_base, sec0, time_base0
-	character (len=*), parameter :: machin1 = "km/hour"
-	character (len=*), parameter :: machin2 = "m/second"
-	character (len=*), parameter :: machin3 = "2 knots"
-	character (len=*), parameter :: machin4 = "watt"
-	character (len=*), parameter :: machin5 = "radian"
-	character (len=128) :: buffer
-	real *8, parameter :: ONE = 1.01
-	real *8, parameter :: TWO = 2.0
-	real *8, parameter :: THREE = 3.03
-	real *8, parameter :: FOUR = 4.04
-	real *8, parameter :: TEN = 10.0
-	real *8, parameter :: ZERO = 0.0
-	real :: A,B
-	integer :: junk
-	integer :: charset
-	integer hour,minute,year,month,day
-	real(C_DOUBLE) :: second, time, resolution
+   type(UT_SYSTEM_PTR) :: sys
+   type(CV_CONVERTER_PTR) :: conv1, conv2, conv3, time_cvt, time_cvt0
+   type(UT_UNIT_PTR) :: unit1, unit2, unit3, unit4, unit5
+   type(UT_UNIT_PTR) :: unit0, unit6, unit7, unit8, unit9, unit06
+   type(UT_UNIT_PTR) :: erg, watt, watt_s, sec, time_base, sec0, time_base0
+   character(len=*), parameter :: machin1 = "km/hour"
+   character(len=*), parameter :: machin2 = "m/second"
+   character(len=*), parameter :: machin3 = "2 knots"
+   character(len=*), parameter :: machin4 = "watt"
+   character(len=*), parameter :: machin5 = "radian"
+   character(len=128) :: buffer
+   real*8, parameter :: ONE = 1.01
+   real*8, parameter :: TWO = 2.0
+   real*8, parameter :: THREE = 3.03
+   real*8, parameter :: FOUR = 4.04
+   real*8, parameter :: TEN = 10.0
+   real*8, parameter :: ZERO = 0.0
+   real :: A, B
+   integer :: junk
+   integer :: charset
+   integer hour, minute, year, month, day
+   real(C_DOUBLE) :: second, time, resolution
 
-	charset = UT_ASCII
-	sys = f_ut_read_xml("")
+   charset = UT_ASCII
+   sys = f_ut_read_xml("")
 
-	year=-2000 ; month=8 ; day=8 ; hour=15 ; minute=45 ; second=15.55 ; resolution=0.0
-	time = f_ut_encode_time(year,month,day,hour,minute,second)
-	print *,"TIME=",time," =<",year,month,day,hour,minute,real(second)
-	year=0 ; month=0 ; day=0 ; hour=0 ; minute=0 ; second=0.0 ; resolution=-999.999
-	call f_ut_decode_time(time,year,month,day,hour,minute,second,resolution)
-	print *,"TIME=",time," =>",year,month,day,hour,minute,real(second)," +-",real(resolution)
+   year = -2000; month = 8; day = 8; hour = 15; minute = 45; second = 15.55; resolution = 0.0
+   time = f_ut_encode_time(year, month, day, hour, minute, second)
+   print *, "TIME=", time, " =<", year, month, day, hour, minute, real(second)
+   year = 0; month = 0; day = 0; hour = 0; minute = 0; second = 0.0; resolution = -999.999
+   call f_ut_decode_time(time, year, month, day, hour, minute, second, resolution)
+   print *, "TIME=", time, " =>", year, month, day, hour, minute, real(second), " +-", real(resolution)
 
-	sec0 = f_ut_parse(sys,"second",charset)
-	time_base = f_ut_offset_by_time(sec0,f_ut_encode_time(2012,08,08,15,00,ZERO))
-	time_base0 = f_ut_offset_by_time(sec0,f_ut_encode_time(2001,01,01,00,00,ZERO))
-	time_cvt = f_ut_get_converter(sec0,time_base)
-	if(.not. c_associated(time_cvt%ptr)) print *,'ERROR in time_cvt'
-	time_cvt0 = f_ut_get_converter(sec0,time_base0)
-	if(.not. c_associated(time_cvt0%ptr)) print *,'ERROR in time_cvt0'
-	junk = f_ut_format(time_base,buffer,UT_NAMES)
-	print *,"DEBUG: new unit of time_base='",trim(buffer),"'"
-	print *,"converted time =",f_cv_convert_double(time_cvt,time)
-	junk = f_ut_format(time_base0,buffer,UT_NAMES)
-	print *,"DEBUG: new unit of time_base='",trim(buffer),"'"
-	print *,"converted time =",f_cv_convert_double(time_cvt0,time)
+   sec0 = f_ut_parse(sys, "second", charset)
+   time_base = f_ut_offset_by_time(sec0, f_ut_encode_time(2012, 08, 08, 15, 00, ZERO))
+   time_base0 = f_ut_offset_by_time(sec0, f_ut_encode_time(2001, 01, 01, 00, 00, ZERO))
+   time_cvt = f_ut_get_converter(sec0, time_base)
+   if (.not. c_associated(time_cvt%ptr)) print *, 'ERROR in time_cvt'
+   time_cvt0 = f_ut_get_converter(sec0, time_base0)
+   if (.not. c_associated(time_cvt0%ptr)) print *, 'ERROR in time_cvt0'
+   junk = f_ut_format(time_base, buffer, UT_NAMES)
+   print *, "DEBUG: new unit of time_base='", trim(buffer), "'"
+   print *, "converted time =", f_cv_convert_double(time_cvt, time)
+   junk = f_ut_format(time_base0, buffer, UT_NAMES)
+   print *, "DEBUG: new unit of time_base='", trim(buffer), "'"
+   print *, "converted time =", f_cv_convert_double(time_cvt0, time)
 
-	unit1 = f_ut_parse(sys,machin1,charset)
-	if(.not. c_associated(unit1%ptr)) print *,'ERROR in unit1'
+   unit1 = f_ut_parse(sys, machin1, charset)
+   if (.not. c_associated(unit1%ptr)) print *, 'ERROR in unit1'
 
-	junk = f_ut_format(unit1,buffer,UT_NAMES)
-	print *,"DEBUG: unit UT_NAMES of ",machin1,"='",trim(buffer),"'"
-	junk = f_ut_format(unit1,buffer,UT_DEFINITION)
-	print *,"DEBUG: unit UT_DEFINITION of ",machin1,"='",trim(buffer),"'"
+   junk = f_ut_format(unit1, buffer, UT_NAMES)
+   print *, "DEBUG: unit UT_NAMES of ", machin1, "='", trim(buffer), "'"
+   junk = f_ut_format(unit1, buffer, UT_DEFINITION)
+   print *, "DEBUG: unit UT_DEFINITION of ", machin1, "='", trim(buffer), "'"
 
-	unit2 = f_ut_parse(sys,machin2,charset)
+   unit2 = f_ut_parse(sys, machin2, charset)
 
-	if(.not. c_associated(unit2%ptr)) print *,'ERROR in unit2'
-	junk = f_ut_format(unit2,buffer,UT_NAMES)
-	print *,"DEBUG: unit UT_NAMES of ",machin2,"='",trim(buffer),"'"
-	junk = f_ut_format(unit2,buffer,UT_DEFINITION)
-	print *,"DEBUG: unit UT_DEFINITION of ",machin2,"='",trim(buffer),"'"
+   if (.not. c_associated(unit2%ptr)) print *, 'ERROR in unit2'
+   junk = f_ut_format(unit2, buffer, UT_NAMES)
+   print *, "DEBUG: unit UT_NAMES of ", machin2, "='", trim(buffer), "'"
+   junk = f_ut_format(unit2, buffer, UT_DEFINITION)
+   print *, "DEBUG: unit UT_DEFINITION of ", machin2, "='", trim(buffer), "'"
 
-	conv1 = f_ut_get_converter(unit1,unit2)   ! machin2 to machin1
-	if(f_ut_are_convertible(unit1,unit2))  print *,machin1," can be converted into ",machin2
-	if(.not. c_associated(conv1%ptr)) print *,'ERROR in conv1'
-	a =1.5
-	B = f_cv_convert_float(conv1,A)
-	print *,a,machin1,' is the same as',b,machin2
+   conv1 = f_ut_get_converter(unit1, unit2)   ! machin2 to machin1
+   if (f_ut_are_convertible(unit1, unit2)) print *, machin1, " can be converted into ", machin2
+   if (.not. c_associated(conv1%ptr)) print *, 'ERROR in conv1'
+   a = 1.5
+   B = f_cv_convert_float(conv1, A)
+   print *, a, machin1, ' is the same as', b, machin2
 
-	unit3 = f_ut_parse(sys,machin3,charset)
-	if(.not. c_associated(unit3%ptr)) print *,'ERROR in unit3'
-	junk = f_ut_format(unit3,buffer,UT_NAMES)
-	print *,"DEBUG: unit UT_NAMES of ",machin3,"='",trim(buffer),"'"
-	junk = f_ut_format(unit3,buffer,UT_DEFINITION)
-	print *,"DEBUG: unit UT_DEFINITION of ",machin3,"='",trim(buffer),"'"
+   unit3 = f_ut_parse(sys, machin3, charset)
+   if (.not. c_associated(unit3%ptr)) print *, 'ERROR in unit3'
+   junk = f_ut_format(unit3, buffer, UT_NAMES)
+   print *, "DEBUG: unit UT_NAMES of ", machin3, "='", trim(buffer), "'"
+   junk = f_ut_format(unit3, buffer, UT_DEFINITION)
+   print *, "DEBUG: unit UT_DEFINITION of ", machin3, "='", trim(buffer), "'"
 
-	conv2 = f_ut_get_converter(unit3,unit1)   ! machin3 to machin1
-	if(f_ut_are_convertible(unit3,unit1))  print *,machin3," can be converted into ",machin1
-	if(.not. c_associated(conv2%ptr)) print *,'ERROR in conv2'
-	a = 1.5
-	B = f_cv_convert_float(conv2,A)
-	print *,a,machin3,' is the same as',b,machin1
+   conv2 = f_ut_get_converter(unit3, unit1)   ! machin3 to machin1
+   if (f_ut_are_convertible(unit3, unit1)) print *, machin3, " can be converted into ", machin1
+   if (.not. c_associated(conv2%ptr)) print *, 'ERROR in conv2'
+   a = 1.5
+   B = f_cv_convert_float(conv2, A)
+   print *, a, machin3, ' is the same as', b, machin1
 
-	conv3 = f_ut_get_converter(unit3,unit2)   ! machin3 to machin2
-	if(f_ut_are_convertible(unit3,unit2))  print *,machin3," can be converted into ",machin2
-	if(.not. c_associated(conv3%ptr)) print *,'ERROR in conv3'
-	a = 1.5
-	B = f_cv_convert_float(conv3,A)
-	print *,a,machin3,' is the same as',b,machin2
-	print *,"COMPARE ",machin1," with ",machin1," = ",f_ut_compare(unit1,unit1), &
-                ", same system =",f_ut_same_system(unit1,unit1)
-	print *,"COMPARE ",machin1," with ",machin2," = ",f_ut_compare(unit1,unit2), &
-                ", same system =",f_ut_same_system(unit1,unit2)
-	print *,"COMPARE ",machin1," with ",machin3," = ",f_ut_compare(unit1,unit3), &
-                ", same system =",f_ut_same_system(unit1,unit3)
-	print *,"COMPARE ",machin2," with ",machin3," = ",f_ut_compare(unit2,unit3), &
-                ", same system =",f_ut_same_system(unit2,unit3)
+   conv3 = f_ut_get_converter(unit3, unit2)   ! machin3 to machin2
+   if (f_ut_are_convertible(unit3, unit2)) print *, machin3, " can be converted into ", machin2
+   if (.not. c_associated(conv3%ptr)) print *, 'ERROR in conv3'
+   a = 1.5
+   B = f_cv_convert_float(conv3, A)
+   print *, a, machin3, ' is the same as', b, machin2
+   print *, "COMPARE ", machin1, " with ", machin1, " = ", f_ut_compare(unit1, unit1), &
+      ", same system =", f_ut_same_system(unit1, unit1)
+   print *, "COMPARE ", machin1, " with ", machin2, " = ", f_ut_compare(unit1, unit2), &
+      ", same system =", f_ut_same_system(unit1, unit2)
+   print *, "COMPARE ", machin1, " with ", machin3, " = ", f_ut_compare(unit1, unit3), &
+      ", same system =", f_ut_same_system(unit1, unit3)
+   print *, "COMPARE ", machin2, " with ", machin3, " = ", f_ut_compare(unit2, unit3), &
+      ", same system =", f_ut_same_system(unit2, unit3)
 
-	unit4 = f_ut_parse(sys,machin4,charset)
-	if(.not. c_associated(unit4%ptr)) print *,'ERROR in unit4'
-	if(.not. f_ut_are_convertible(unit3,unit4))  print *,machin3," cannot be converted into ",machin4, &
-	                                             ", same system =",f_ut_same_system(unit3,unit4)
-	print *,machin4," is dimensionless =",f_ut_is_dimensionless(unit4)
-	unit5 = f_ut_parse(sys,machin5,charset)
-	if(.not. c_associated(unit5%ptr)) print *,'ERROR in unit5'
-	print *,machin5," is dimensionless =",f_ut_is_dimensionless(unit5)
+   unit4 = f_ut_parse(sys, machin4, charset)
+   if (.not. c_associated(unit4%ptr)) print *, 'ERROR in unit4'
+   if (.not. f_ut_are_convertible(unit3, unit4)) print *, machin3, " cannot be converted into ", machin4, &
+      ", same system =", f_ut_same_system(unit3, unit4)
+   print *, machin4, " is dimensionless =", f_ut_is_dimensionless(unit4)
+   unit5 = f_ut_parse(sys, machin5, charset)
+   if (.not. c_associated(unit5%ptr)) print *, 'ERROR in unit5'
+   print *, machin5, " is dimensionless =", f_ut_is_dimensionless(unit5)
 
-	junk = f_ut_format(unit4,buffer,UT_NAMES)
-	print *,"DEBUG: unit ='",trim(buffer),"'"
-	junk = f_ut_format(unit5,buffer,UT_NAMES)
-	print *,"DEBUG: unit ='",trim(buffer),"'"
-	unit6=f_ut_divide(unit4,unit5)
-	print *,"DIVIDE ",machin4," by ",machin5
-	junk = f_ut_format(unit6,buffer,UT_NAMES)
-	print *,"DEBUG: new unit = '",trim(buffer),"'"
-	print *,"MULTIPLY by ",machin5
-	unit06=f_ut_multiply(unit6,unit5)
-	junk = f_ut_format(unit06,buffer,UT_NAMES)
-	print *,"DEBUG: new unit = '",trim(buffer),"'"
-	print *,"SCALE by",THREE
-	unit7=f_ut_scale(THREE,unit06)
-	junk = f_ut_format(unit7,buffer,UT_NAMES)
-	print *,"DEBUG: new unit = '",trim(buffer),"'"
-	print *,"OFFSET by", FOUR
-	unit8=f_ut_offset(unit7,FOUR)
-	junk = f_ut_format(unit8,buffer,UT_NAMES)
-	print *,"DEBUG: new unit = '",trim(buffer),"'"
-	junk = f_ut_format(unit7,buffer,UT_NAMES)
-	print *,"RAISE 3 ",trim(buffer)
-	unit9=f_ut_raise(unit7,3)
-	junk = f_ut_format(unit9,buffer,UT_NAMES)
-	print *,"DEBUG: new unit = '",trim(buffer),"'"
-	print *,"INVERT"
-	unit0=f_ut_invert(unit9)
-	junk = f_ut_format(unit0,buffer,UT_NAMES)
-	print *,"DEBUG: new unit = '",trim(buffer),"'"
-	call f_ut_free(unit0)
-	print *,"root 2"
-	unit0=f_ut_root(unit9,2)
-	print *,"LOG",TWO
-	unit0=f_ut_log(TWO,unit9)
-	junk = f_ut_format(unit0,buffer,UT_NAMES)
-	print *,"DEBUG: new unit = '",trim(buffer),"'"
-	call f_ut_free(unit0)
-	print *,"LOG",TEN
-	unit0=f_ut_log(TEN,unit9)
-	junk = f_ut_format(unit0,buffer,UT_NAMES)
-	print *,"DEBUG: new unit = '",trim(buffer),"'"
-	call f_ut_free(unit0)
-	print *,"LOG",FOUR
-	unit0=f_ut_log(FOUR,unit9)
-	junk = f_ut_format(unit0,buffer,UT_NAMES)
-	print *,"DEBUG: new unit = '",trim(buffer),"'"
-	call f_ut_free(unit0)
-	print *,"root 3"
-	unit0=f_ut_root(unit9,3)
-	junk = f_ut_format(unit0,buffer,UT_NAMES)
-	print *,"DEBUG: new unit = '",trim(buffer),"'"
+   junk = f_ut_format(unit4, buffer, UT_NAMES)
+   print *, "DEBUG: unit ='", trim(buffer), "'"
+   junk = f_ut_format(unit5, buffer, UT_NAMES)
+   print *, "DEBUG: unit ='", trim(buffer), "'"
+   unit6 = f_ut_divide(unit4, unit5)
+   print *, "DIVIDE ", machin4, " by ", machin5
+   junk = f_ut_format(unit6, buffer, UT_NAMES)
+   print *, "DEBUG: new unit = '", trim(buffer), "'"
+   print *, "MULTIPLY by ", machin5
+   unit06 = f_ut_multiply(unit6, unit5)
+   junk = f_ut_format(unit06, buffer, UT_NAMES)
+   print *, "DEBUG: new unit = '", trim(buffer), "'"
+   print *, "SCALE by", THREE
+   unit7 = f_ut_scale(THREE, unit06)
+   junk = f_ut_format(unit7, buffer, UT_NAMES)
+   print *, "DEBUG: new unit = '", trim(buffer), "'"
+   print *, "OFFSET by", FOUR
+   unit8 = f_ut_offset(unit7, FOUR)
+   junk = f_ut_format(unit8, buffer, UT_NAMES)
+   print *, "DEBUG: new unit = '", trim(buffer), "'"
+   junk = f_ut_format(unit7, buffer, UT_NAMES)
+   print *, "RAISE 3 ", trim(buffer)
+   unit9 = f_ut_raise(unit7, 3)
+   junk = f_ut_format(unit9, buffer, UT_NAMES)
+   print *, "DEBUG: new unit = '", trim(buffer), "'"
+   print *, "INVERT"
+   unit0 = f_ut_invert(unit9)
+   junk = f_ut_format(unit0, buffer, UT_NAMES)
+   print *, "DEBUG: new unit = '", trim(buffer), "'"
+   call f_ut_free(unit0)
+   print *, "root 2"
+   unit0 = f_ut_root(unit9, 2)
+   print *, "LOG", TWO
+   unit0 = f_ut_log(TWO, unit9)
+   junk = f_ut_format(unit0, buffer, UT_NAMES)
+   print *, "DEBUG: new unit = '", trim(buffer), "'"
+   call f_ut_free(unit0)
+   print *, "LOG", TEN
+   unit0 = f_ut_log(TEN, unit9)
+   junk = f_ut_format(unit0, buffer, UT_NAMES)
+   print *, "DEBUG: new unit = '", trim(buffer), "'"
+   call f_ut_free(unit0)
+   print *, "LOG", FOUR
+   unit0 = f_ut_log(FOUR, unit9)
+   junk = f_ut_format(unit0, buffer, UT_NAMES)
+   print *, "DEBUG: new unit = '", trim(buffer), "'"
+   call f_ut_free(unit0)
+   print *, "root 3"
+   unit0 = f_ut_root(unit9, 3)
+   junk = f_ut_format(unit0, buffer, UT_NAMES)
+   print *, "DEBUG: new unit = '", trim(buffer), "'"
 
-	watt = f_ut_parse(sys,"watt",charset)
-	sec = f_ut_parse(sys,"second",charset)
-	erg = f_ut_parse(sys,"erg",charset)
-	watt_s = f_ut_multiply(watt,sec)
-	junk = f_ut_format(watt_s,buffer,UT_NAMES)
-	print *,"DEBUG: watt_s = '",trim(buffer),"'"
-	junk = f_ut_format(erg,buffer,UT_NAMES)
-	print *,"DEBUG: erg = '",trim(buffer),"'"
-	if(f_ut_are_convertible(watt_s,erg))  print *,"watt.s can be converted into erg"
+   watt = f_ut_parse(sys, "watt", charset)
+   sec = f_ut_parse(sys, "second", charset)
+   erg = f_ut_parse(sys, "erg", charset)
+   watt_s = f_ut_multiply(watt, sec)
+   junk = f_ut_format(watt_s, buffer, UT_NAMES)
+   print *, "DEBUG: watt_s = '", trim(buffer), "'"
+   junk = f_ut_format(erg, buffer, UT_NAMES)
+   print *, "DEBUG: erg = '", trim(buffer), "'"
+   if (f_ut_are_convertible(watt_s, erg)) print *, "watt.s can be converted into erg"
 
-    print *,'UNIT4 name is ',trim(f_ut_get_name(unit4,UT_ASCII))
-    print *,'UNIT4 symbol is ',trim(f_ut_get_symbol(unit4,UT_ASCII))
-    print *,'UNIT5 name is ',trim(f_ut_get_name(unit5,UT_ASCII))
-    print *,'UNIT5 symbol is ',trim(f_ut_get_symbol(unit5,UT_ASCII))
-    print *,'sec name is ',trim(f_ut_get_name(sec,UT_ASCII))
-    print *,'sec symbol is ',trim(f_ut_get_symbol(sec,UT_ASCII))
+   print *, 'UNIT4 name is ', trim(f_ut_get_name(unit4, UT_ASCII))
+   print *, 'UNIT4 symbol is ', trim(f_ut_get_symbol(unit4, UT_ASCII))
+   print *, 'UNIT5 name is ', trim(f_ut_get_name(unit5, UT_ASCII))
+   print *, 'UNIT5 symbol is ', trim(f_ut_get_symbol(unit5, UT_ASCII))
+   print *, 'sec name is ', trim(f_ut_get_name(sec, UT_ASCII))
+   print *, 'sec symbol is ', trim(f_ut_get_symbol(sec, UT_ASCII))
 
-	call f_ut_free(unit1)
-	call f_ut_free(unit2)
-	call f_ut_free(unit3)
-	call f_ut_free(unit4)
-	call f_cv_free(conv1)
-	call f_cv_free(conv2)
-	call f_cv_free(conv3)
-	call f_ut_free_system(sys)
+   call f_ut_free(unit1)
+   call f_ut_free(unit2)
+   call f_ut_free(unit3)
+   call f_ut_free(unit4)
+   call f_cv_free(conv1)
+   call f_cv_free(conv2)
+   call f_cv_free(conv3)
+   call f_ut_free_system(sys)
 !
-	stop
-	end
+   stop
+end

--- a/tests/test_f_udunits_2.F90
+++ b/tests/test_f_udunits_2.F90
@@ -1,4 +1,3 @@
-#include <f_udunits_2.F90>
 	program test_f_udunits_2  ! very rudimentary test program for libudunits2 Fortran nterface
 !
 ! example of compilation and execution with gfortran (udunits2 installed in /opt/udunits2)


### PR DESCRIPTION
This is a WIP PR to add CMake to fortran_udunits2. I've done a few things:

1. "Borrowed" the [`Findudunits.cmake`](https://github.com/NOAA-EMC/CMakeModules/blob/develop/Modules/Findudunits.cmake) file from NOAA-EMC (cc @climbfuji)
2. Edited the `Findudunits.cmake` file because Baselibs only provides a static `libudunits2.a` and my attempts to link to it (see below) were failing since the current one is static only
3. Used the [trick @scivision code](https://www.scivision.dev/cmake-auto-gitignore-build-dir/) to ignore build and install directories (much like we do in GEOS)
4. Added a `.gitignore` so that common editor temp files don't get committed.
5. Added an `.editorconfig` file because Vim was unhappy for some reason without it!
6. Ran `fprettify` on some of the Fortran code because my editor was *not* happy.
7. Converted all the `FORTRAN` to `Fortran` to make @tclune happy. 😄 

I think this is good to go.